### PR TITLE
Implement FTP ingestion for PubChem SDF data

### DIFF
--- a/config/ingestion-example.yaml
+++ b/config/ingestion-example.yaml
@@ -9,12 +9,10 @@ job:
     - type: pubchem
       name: pubchem
       options:
-        base_url: https://example.test/pubchem
-        endpoint: v1/records
-        records_path: [records]
-        next_cursor_path: [next]
-        id_field: cid
-        smiles_field: smiles
+        ftp_host: ftp.ncbi.nlm.nih.gov
+        ftp_directory: pubchem/Compound/CURRENT-Full/SDF
+        identifier_tag: PUBCHEM_COMPOUND_CID
+        smiles_tag: PUBCHEM_OPENEYE_ISO_SMILES
     - type: zinc
       name: zinc
       options:

--- a/src/ingestion/__init__.py
+++ b/src/ingestion/__init__.py
@@ -3,6 +3,7 @@
 from .chembl import ChEMBLConfig, ChEMBLConnector
 from .chemspider import ChemSpiderConfig, ChemSpiderConnector
 from .common import (
+    BaseConnector,
     BaseHttpConnector,
     CheckpointManager,
     HttpSourceConfig,
@@ -10,12 +11,14 @@ from .common import (
     IngestionPage,
     MoleculeRecord,
     NDJSONWriter,
+    SourceConfig,
 )
 from .pubchem import PubChemConfig, PubChemConnector
 from .runner import IngestionJobConfig, SourceDefinition, load_config, run_ingestion
 from .zinc import ZincConfig, ZincConnector
 
 __all__ = [
+    "BaseConnector",
     "BaseHttpConnector",
     "CheckpointManager",
     "HttpSourceConfig",
@@ -24,6 +27,7 @@ __all__ = [
     "IngestionPage",
     "MoleculeRecord",
     "NDJSONWriter",
+    "SourceConfig",
     "SourceDefinition",
     "load_config",
     "run_ingestion",

--- a/src/ingestion/pubchem.py
+++ b/src/ingestion/pubchem.py
@@ -2,31 +2,232 @@
 
 from __future__ import annotations
 
+import contextlib
+import ftplib
+import gzip
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from pathlib import Path
+import tempfile
+from typing import Any
+
+import structlog
 from pydantic import Field
 
-from .common import BaseHttpConnector, HttpSourceConfig
+from .common import BaseConnector, CheckpointManager, IngestionPage, MoleculeRecord, SourceConfig
+
+logger = structlog.get_logger(__name__)
 
 
-class PubChemConfig(HttpSourceConfig):
-    """Configuration defaults tailored for the PubChem REST API."""
+class PubChemConfig(SourceConfig):
+    """Configuration for downloading PubChem SDF bundles over FTP."""
 
-    base_url: str = "https://pubchem.ncbi.nlm.nih.gov"
-    endpoint: str = "rest/pug/compound/cid/JSON"
-    batch_param: str = "page_size"
-    cursor_param: str | None = "page"
-    records_path: list[str] = Field(default_factory=lambda: ["results"])
-    next_cursor_path: list[str] = Field(default_factory=lambda: ["pagination", "next_page"])
-    id_field: str = "cid"
-    smiles_field: str = "smiles"
-    metadata_fields: list[str] = Field(
-        default_factory=lambda: ["inchi_key", "molecular_formula", "canonical_name"]
-    )
+    ftp_host: str = "ftp.ncbi.nlm.nih.gov"
+    ftp_port: int = 21
+    ftp_directory: str = "pubchem/Compound/CURRENT-Full/SDF"
+    ftp_username: str = "anonymous"
+    ftp_password: str = "anonymous@"
+    passive_mode: bool = True
+    timeout: float = 60.0
+    file_suffixes: list[str] = Field(default_factory=lambda: [".sdf.gz", ".sdf"])
+    identifier_tag: str = "PUBCHEM_COMPOUND_CID"
+    smiles_tag: str = "PUBCHEM_OPENEYE_ISO_SMILES"
+    metadata_tags: list[str] = Field(default_factory=list)
 
 
-class PubChemConnector(BaseHttpConnector):
-    """Connector that downloads SMILES data from PubChem."""
+class PubChemConnector(BaseConnector):
+    """Connector that downloads and parses PubChem SDF archives via FTP."""
 
     config: PubChemConfig
+
+    def __init__(
+        self,
+        config: PubChemConfig,
+        checkpoint_manager: CheckpointManager,
+        ftp_factory: Callable[[], ftplib.FTP] | None = None,
+    ) -> None:
+        super().__init__(config=config, checkpoint_manager=checkpoint_manager)
+        self._ftp_factory = ftp_factory or self._create_default_ftp
+        self._ftp: ftplib.FTP | None = None
+
+    def _create_default_ftp(self) -> ftplib.FTP:
+        ftp = ftplib.FTP()
+        ftp.connect(self.config.ftp_host, self.config.ftp_port, timeout=self.config.timeout)
+        ftp.login(self.config.ftp_username, self.config.ftp_password)
+        ftp.set_pasv(self.config.passive_mode)
+        ftp.cwd(self.config.ftp_directory)
+        return ftp
+
+    def _ensure_ftp(self) -> ftplib.FTP:
+        if self._ftp is None:
+            ftp = self._ftp_factory()
+            try:
+                ftp.cwd(self.config.ftp_directory)
+            except ftplib.all_errors:
+                # Directory might already be set by the factory; ignore errors to avoid
+                # breaking custom factories in tests.
+                pass
+            self._ftp = ftp
+        return self._ftp
+
+    def _list_remote_files(self, ftp: ftplib.FTP) -> list[str]:
+        names = ftp.nlst()
+        suffixes = tuple(self.config.file_suffixes)
+        if suffixes:
+            names = [name for name in names if name.endswith(suffixes)]
+        return sorted(names)
+
+    @contextlib.contextmanager
+    def _download_file(self, ftp: ftplib.FTP, filename: str) -> Iterator[Path]:
+        suffix = Path(filename).suffix
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+            ftp.retrbinary(f"RETR {filename}", handle.write)
+            temp_path = Path(handle.name)
+        try:
+            yield temp_path
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                temp_path.unlink()
+
+    @contextlib.contextmanager
+    def _open_sdf_stream(self, path: Path) -> Iterator[Iterable[str]]:
+        if path.suffix == ".gz":
+            with gzip.open(path, "rt", encoding="utf-8", errors="replace") as stream:
+                yield stream
+        else:
+            with path.open("r", encoding="utf-8", errors="replace") as stream:
+                yield stream
+
+    @staticmethod
+    def _parse_entry(lines: list[str]) -> dict[str, str]:
+        properties: dict[str, str] = {}
+        current_tag: str | None = None
+        buffer: list[str] = []
+        for line in lines:
+            if line.startswith(">"):
+                if current_tag is not None:
+                    properties[current_tag] = "\n".join(buffer).strip()
+                start = line.find("<")
+                end = line.find(">", start + 1)
+                if start != -1 and end != -1:
+                    current_tag = line[start + 1 : end].strip()
+                    buffer = []
+                else:
+                    current_tag = None
+                    buffer = []
+            elif current_tag is not None:
+                buffer.append(line.rstrip("\r"))
+        if current_tag is not None:
+            properties[current_tag] = "\n".join(buffer).strip()
+        return properties
+
+    def _iter_sdf_entries(self, ftp: ftplib.FTP, filename: str) -> Iterator[dict[str, str]]:
+        with self._download_file(ftp, filename) as temp_path:
+            with self._open_sdf_stream(temp_path) as stream:
+                entry_lines: list[str] = []
+                for raw_line in stream:
+                    line = raw_line.rstrip("\n")
+                    if line.strip() == "$$$$":
+                        if entry_lines:
+                            yield self._parse_entry(entry_lines)
+                            entry_lines = []
+                    else:
+                        entry_lines.append(line)
+                if entry_lines:
+                    yield self._parse_entry(entry_lines)
+
+    def _build_record(self, properties: Mapping[str, str]) -> MoleculeRecord:
+        identifier = properties.get(self.config.identifier_tag, "").strip()
+        smiles = properties.get(self.config.smiles_tag, "").strip()
+        metadata: dict[str, Any] = {
+            key: value
+            for key, value in properties.items()
+            if key not in {self.config.identifier_tag, self.config.smiles_tag}
+        }
+        if self.config.metadata_tags:
+            metadata = {
+                key: metadata[key]
+                for key in self.config.metadata_tags
+                if key in metadata
+            }
+        metadata = {key: value for key, value in metadata.items() if value}
+        return MoleculeRecord(
+            source=self.config.name,
+            identifier=identifier,
+            smiles=smiles,
+            metadata=metadata,
+        )
+
+    def fetch_pages(self) -> Iterator[IngestionPage]:
+        checkpoint = self._checkpoint_manager.load(self.config.name)
+        if checkpoint and checkpoint.completed:
+            logger.info("ingestion.skip", source=self.config.name, reason="completed")
+            return
+
+        ftp = self._ensure_ftp()
+        filenames = self._list_remote_files(ftp)
+
+        start_file = 0
+        start_offset = 0
+        if checkpoint:
+            start_file = int(checkpoint.cursor.get("file_index", 0))
+            start_offset = int(checkpoint.cursor.get("record_offset", 0))
+
+        if start_file >= len(filenames):
+            yield IngestionPage(records=[], next_cursor=None)
+            return
+
+        batch: list[MoleculeRecord] = []
+        current_file = start_file
+        current_offset = start_offset
+        yielded = False
+
+        while current_file < len(filenames):
+            filename = filenames[current_file]
+            logger.info("ingestion.pubchem.file", source=self.config.name, file=filename)
+            entry_index = 0
+            for entry in self._iter_sdf_entries(ftp, filename):
+                if entry_index < current_offset:
+                    entry_index += 1
+                    continue
+                record = self._build_record(entry)
+                batch.append(record)
+                entry_index += 1
+                if len(batch) >= self.config.batch_size:
+                    next_cursor = {
+                        "file_index": current_file,
+                        "file_name": filename,
+                        "record_offset": entry_index,
+                    }
+                    yielded = True
+                    yield IngestionPage(records=list(batch), next_cursor=next_cursor)
+                    batch.clear()
+            current_file += 1
+            current_offset = 0
+            if batch:
+                next_cursor = (
+                    {
+                        "file_index": current_file,
+                        "file_name": filenames[current_file]
+                        if current_file < len(filenames)
+                        else None,
+                        "record_offset": 0,
+                    }
+                    if current_file < len(filenames)
+                    else None
+                )
+                yielded = True
+                yield IngestionPage(records=list(batch), next_cursor=next_cursor)
+                batch.clear()
+
+        if not yielded:
+            yield IngestionPage(records=[], next_cursor=None)
+
+    def close(self) -> None:
+        if self._ftp is None:
+            return
+        with contextlib.suppress(Exception):
+            self._ftp.quit()
+        self._ftp = None
 
 
 __all__ = ["PubChemConfig", "PubChemConnector"]

--- a/src/open_molecule_data_pipeline/ingestion/__init__.py
+++ b/src/open_molecule_data_pipeline/ingestion/__init__.py
@@ -3,6 +3,7 @@
 from .chembl import ChEMBLConfig, ChEMBLConnector
 from .chemspider import ChemSpiderConfig, ChemSpiderConnector
 from .common import (
+    BaseConnector,
     BaseHttpConnector,
     CheckpointManager,
     HttpSourceConfig,
@@ -10,12 +11,14 @@ from .common import (
     IngestionPage,
     MoleculeRecord,
     NDJSONWriter,
+    SourceConfig,
 )
 from .pubchem import PubChemConfig, PubChemConnector
 from .runner import IngestionJobConfig, SourceDefinition, load_config, run_ingestion
 from .zinc import ZincConfig, ZincConnector
 
 __all__ = [
+    "BaseConnector",
     "BaseHttpConnector",
     "CheckpointManager",
     "HttpSourceConfig",
@@ -24,6 +27,7 @@ __all__ = [
     "IngestionPage",
     "MoleculeRecord",
     "NDJSONWriter",
+    "SourceConfig",
     "SourceDefinition",
     "load_config",
     "run_ingestion",

--- a/src/open_molecule_data_pipeline/ingestion/pubchem.py
+++ b/src/open_molecule_data_pipeline/ingestion/pubchem.py
@@ -2,31 +2,232 @@
 
 from __future__ import annotations
 
+import contextlib
+import ftplib
+import gzip
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from pathlib import Path
+import tempfile
+from typing import Any
+
+import structlog
 from pydantic import Field
 
-from .common import BaseHttpConnector, HttpSourceConfig
+from .common import BaseConnector, CheckpointManager, IngestionPage, MoleculeRecord, SourceConfig
+
+logger = structlog.get_logger(__name__)
 
 
-class PubChemConfig(HttpSourceConfig):
-    """Configuration defaults tailored for the PubChem REST API."""
+class PubChemConfig(SourceConfig):
+    """Configuration for downloading PubChem SDF bundles over FTP."""
 
-    base_url: str = "https://pubchem.ncbi.nlm.nih.gov"
-    endpoint: str = "rest/pug/compound/cid/JSON"
-    batch_param: str = "page_size"
-    cursor_param: str | None = "page"
-    records_path: list[str] = Field(default_factory=lambda: ["results"])
-    next_cursor_path: list[str] = Field(default_factory=lambda: ["pagination", "next_page"])
-    id_field: str = "cid"
-    smiles_field: str = "smiles"
-    metadata_fields: list[str] = Field(
-        default_factory=lambda: ["inchi_key", "molecular_formula", "canonical_name"]
-    )
+    ftp_host: str = "ftp.ncbi.nlm.nih.gov"
+    ftp_port: int = 21
+    ftp_directory: str = "pubchem/Compound/CURRENT-Full/SDF"
+    ftp_username: str = "anonymous"
+    ftp_password: str = "anonymous@"
+    passive_mode: bool = True
+    timeout: float = 60.0
+    file_suffixes: list[str] = Field(default_factory=lambda: [".sdf.gz", ".sdf"])
+    identifier_tag: str = "PUBCHEM_COMPOUND_CID"
+    smiles_tag: str = "PUBCHEM_OPENEYE_ISO_SMILES"
+    metadata_tags: list[str] = Field(default_factory=list)
 
 
-class PubChemConnector(BaseHttpConnector):
-    """Connector that downloads SMILES data from PubChem."""
+class PubChemConnector(BaseConnector):
+    """Connector that downloads and parses PubChem SDF archives via FTP."""
 
     config: PubChemConfig
+
+    def __init__(
+        self,
+        config: PubChemConfig,
+        checkpoint_manager: CheckpointManager,
+        ftp_factory: Callable[[], ftplib.FTP] | None = None,
+    ) -> None:
+        super().__init__(config=config, checkpoint_manager=checkpoint_manager)
+        self._ftp_factory = ftp_factory or self._create_default_ftp
+        self._ftp: ftplib.FTP | None = None
+
+    def _create_default_ftp(self) -> ftplib.FTP:
+        ftp = ftplib.FTP()
+        ftp.connect(self.config.ftp_host, self.config.ftp_port, timeout=self.config.timeout)
+        ftp.login(self.config.ftp_username, self.config.ftp_password)
+        ftp.set_pasv(self.config.passive_mode)
+        ftp.cwd(self.config.ftp_directory)
+        return ftp
+
+    def _ensure_ftp(self) -> ftplib.FTP:
+        if self._ftp is None:
+            ftp = self._ftp_factory()
+            try:
+                ftp.cwd(self.config.ftp_directory)
+            except ftplib.all_errors:
+                # Directory might already be set by the factory; ignore errors to avoid
+                # breaking custom factories in tests.
+                pass
+            self._ftp = ftp
+        return self._ftp
+
+    def _list_remote_files(self, ftp: ftplib.FTP) -> list[str]:
+        names = ftp.nlst()
+        suffixes = tuple(self.config.file_suffixes)
+        if suffixes:
+            names = [name for name in names if name.endswith(suffixes)]
+        return sorted(names)
+
+    @contextlib.contextmanager
+    def _download_file(self, ftp: ftplib.FTP, filename: str) -> Iterator[Path]:
+        suffix = Path(filename).suffix
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+            ftp.retrbinary(f"RETR {filename}", handle.write)
+            temp_path = Path(handle.name)
+        try:
+            yield temp_path
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                temp_path.unlink()
+
+    @contextlib.contextmanager
+    def _open_sdf_stream(self, path: Path) -> Iterator[Iterable[str]]:
+        if path.suffix == ".gz":
+            with gzip.open(path, "rt", encoding="utf-8", errors="replace") as stream:
+                yield stream
+        else:
+            with path.open("r", encoding="utf-8", errors="replace") as stream:
+                yield stream
+
+    @staticmethod
+    def _parse_entry(lines: list[str]) -> dict[str, str]:
+        properties: dict[str, str] = {}
+        current_tag: str | None = None
+        buffer: list[str] = []
+        for line in lines:
+            if line.startswith(">"):
+                if current_tag is not None:
+                    properties[current_tag] = "\n".join(buffer).strip()
+                start = line.find("<")
+                end = line.find(">", start + 1)
+                if start != -1 and end != -1:
+                    current_tag = line[start + 1 : end].strip()
+                    buffer = []
+                else:
+                    current_tag = None
+                    buffer = []
+            elif current_tag is not None:
+                buffer.append(line.rstrip("\r"))
+        if current_tag is not None:
+            properties[current_tag] = "\n".join(buffer).strip()
+        return properties
+
+    def _iter_sdf_entries(self, ftp: ftplib.FTP, filename: str) -> Iterator[dict[str, str]]:
+        with self._download_file(ftp, filename) as temp_path:
+            with self._open_sdf_stream(temp_path) as stream:
+                entry_lines: list[str] = []
+                for raw_line in stream:
+                    line = raw_line.rstrip("\n")
+                    if line.strip() == "$$$$":
+                        if entry_lines:
+                            yield self._parse_entry(entry_lines)
+                            entry_lines = []
+                    else:
+                        entry_lines.append(line)
+                if entry_lines:
+                    yield self._parse_entry(entry_lines)
+
+    def _build_record(self, properties: Mapping[str, str]) -> MoleculeRecord:
+        identifier = properties.get(self.config.identifier_tag, "").strip()
+        smiles = properties.get(self.config.smiles_tag, "").strip()
+        metadata: dict[str, Any] = {
+            key: value
+            for key, value in properties.items()
+            if key not in {self.config.identifier_tag, self.config.smiles_tag}
+        }
+        if self.config.metadata_tags:
+            metadata = {
+                key: metadata[key]
+                for key in self.config.metadata_tags
+                if key in metadata
+            }
+        metadata = {key: value for key, value in metadata.items() if value}
+        return MoleculeRecord(
+            source=self.config.name,
+            identifier=identifier,
+            smiles=smiles,
+            metadata=metadata,
+        )
+
+    def fetch_pages(self) -> Iterator[IngestionPage]:
+        checkpoint = self._checkpoint_manager.load(self.config.name)
+        if checkpoint and checkpoint.completed:
+            logger.info("ingestion.skip", source=self.config.name, reason="completed")
+            return
+
+        ftp = self._ensure_ftp()
+        filenames = self._list_remote_files(ftp)
+
+        start_file = 0
+        start_offset = 0
+        if checkpoint:
+            start_file = int(checkpoint.cursor.get("file_index", 0))
+            start_offset = int(checkpoint.cursor.get("record_offset", 0))
+
+        if start_file >= len(filenames):
+            yield IngestionPage(records=[], next_cursor=None)
+            return
+
+        batch: list[MoleculeRecord] = []
+        current_file = start_file
+        current_offset = start_offset
+        yielded = False
+
+        while current_file < len(filenames):
+            filename = filenames[current_file]
+            logger.info("ingestion.pubchem.file", source=self.config.name, file=filename)
+            entry_index = 0
+            for entry in self._iter_sdf_entries(ftp, filename):
+                if entry_index < current_offset:
+                    entry_index += 1
+                    continue
+                record = self._build_record(entry)
+                batch.append(record)
+                entry_index += 1
+                if len(batch) >= self.config.batch_size:
+                    next_cursor = {
+                        "file_index": current_file,
+                        "file_name": filename,
+                        "record_offset": entry_index,
+                    }
+                    yielded = True
+                    yield IngestionPage(records=list(batch), next_cursor=next_cursor)
+                    batch.clear()
+            current_file += 1
+            current_offset = 0
+            if batch:
+                next_cursor = (
+                    {
+                        "file_index": current_file,
+                        "file_name": filenames[current_file]
+                        if current_file < len(filenames)
+                        else None,
+                        "record_offset": 0,
+                    }
+                    if current_file < len(filenames)
+                    else None
+                )
+                yielded = True
+                yield IngestionPage(records=list(batch), next_cursor=next_cursor)
+                batch.clear()
+
+        if not yielded:
+            yield IngestionPage(records=[], next_cursor=None)
+
+    def close(self) -> None:
+        if self._ftp is None:
+            return
+        with contextlib.suppress(Exception):
+            self._ftp.quit()
+        self._ftp = None
 
 
 __all__ = ["PubChemConfig", "PubChemConnector"]

--- a/tests/unit/ingestion/test_pubchem.py
+++ b/tests/unit/ingestion/test_pubchem.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import gzip
+import io
+from collections.abc import Callable
+from pathlib import Path
+
+from open_molecule_data_pipeline.ingestion.common import (
+    CheckpointManager,
+    IngestionCheckpoint,
+)
+from open_molecule_data_pipeline.ingestion.pubchem import PubChemConfig, PubChemConnector
+
+
+class FakeFTP:
+    """Minimal in-memory FTP server for testing."""
+
+    def __init__(self, files: dict[str, bytes]) -> None:
+        self._files = files
+        self.cwd_path: str | None = None
+        self.closed = False
+
+    def cwd(self, path: str) -> None:  # noqa: D401 - required by ftplib interface
+        self.cwd_path = path
+
+    def nlst(self) -> list[str]:
+        return sorted(self._files)
+
+    def retrbinary(self, cmd: str, callback: Callable[[bytes], object]) -> None:
+        _, filename = cmd.split(maxsplit=1)
+        data = self._files[filename]
+        callback(data)
+
+    def quit(self) -> None:
+        self.closed = True
+
+
+def _gzip_bytes(payload: str) -> bytes:
+    buffer = io.BytesIO()
+    with gzip.GzipFile(fileobj=buffer, mode="wb") as gz:
+        gz.write(payload.encode("utf-8"))
+    return buffer.getvalue()
+
+
+def _sdf_entry(cid: str, smiles: str, **metadata: str) -> str:
+    lines = [
+        "PubChem",
+        "  -OEChem-",
+        "",
+        "  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0",
+        "M  END",
+        ">  <PUBCHEM_COMPOUND_CID>",
+        cid,
+        "",
+        ">  <PUBCHEM_OPENEYE_ISO_SMILES>",
+        smiles,
+        "",
+    ]
+    for key, value in metadata.items():
+        lines.extend([f">  <{key}>", value, ""])
+    lines.append("$$$$")
+    return "\n".join(lines) + "\n"
+
+
+def test_pubchem_connector_batches_records(tmp_path: Path) -> None:
+    file_a = _gzip_bytes(_sdf_entry("CID1", "C") + _sdf_entry("CID2", "CC"))
+    file_b = _gzip_bytes(_sdf_entry("CID3", "CCC", PUBCHEM_IUPAC_NAME="Propane"))
+    files = {"file_a.sdf.gz": file_a, "file_b.sdf.gz": file_b}
+
+    manager = CheckpointManager(tmp_path)
+    connector = PubChemConnector(
+        config=PubChemConfig(name="pubchem", batch_size=2, ftp_directory="."),
+        checkpoint_manager=manager,
+        ftp_factory=lambda: FakeFTP(files),
+    )
+
+    pages = list(connector.fetch_pages())
+    assert len(pages) == 2
+
+    first, second = pages
+    assert [record.identifier for record in first.records] == ["CID1", "CID2"]
+    assert isinstance(first.next_cursor, dict)
+    assert first.next_cursor["record_offset"] == 2
+
+    assert [record.identifier for record in second.records] == ["CID3"]
+    assert second.next_cursor is None
+
+    connector.close()
+
+
+def test_pubchem_connector_resumes_from_checkpoint(tmp_path: Path) -> None:
+    sdf_payload = _sdf_entry("CID1", "C") + _sdf_entry("CID2", "CC") + _sdf_entry("CID3", "CCC")
+    files = {"chunk.sdf.gz": _gzip_bytes(sdf_payload)}
+
+    manager = CheckpointManager(tmp_path)
+    connector = PubChemConnector(
+        config=PubChemConfig(name="pubchem", batch_size=2, ftp_directory="."),
+        checkpoint_manager=manager,
+        ftp_factory=lambda: FakeFTP(files),
+    )
+
+    page_iter = connector.fetch_pages()
+    first_page = next(page_iter)
+    manager.store(
+        "pubchem",
+        IngestionCheckpoint(cursor=first_page.next_cursor or {}, batch_index=1, completed=False),
+    )
+    connector.close()
+
+    resume_connector = PubChemConnector(
+        config=PubChemConfig(name="pubchem", batch_size=2, ftp_directory="."),
+        checkpoint_manager=manager,
+        ftp_factory=lambda: FakeFTP(files),
+    )
+
+    remaining_pages = list(resume_connector.fetch_pages())
+    assert len(remaining_pages) == 1
+    remaining = remaining_pages[0]
+    assert [record.identifier for record in remaining.records] == ["CID3"]
+    assert remaining.next_cursor is None
+    resume_connector.close()


### PR DESCRIPTION
## Summary
- replace the PubChem connector with an FTP-backed implementation that downloads and parses SDF archives
- add shared connector abstractions and runner plumbing so ingestion sources can inject non-HTTP factories
- add unit coverage for the PubChem FTP flow and refresh the sample ingestion configuration

## Testing
- uv run --extra dev pytest

------
https://chatgpt.com/codex/tasks/task_e_68da4471807883219b0766e86565b92a