### PR TITLE
Normalize ZINC wget output paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ uv run smiles ingest --config config/ingestion-example.yaml
 
 Each source writes gzip-compressed NDJSON batches to `data/raw/<source>/` and maintains resumable checkpoints under `data/checkpoints/ingestion/<source>.json`. To resume an interrupted job, re-run the same command; completed sources will be skipped automatically.
 
+### Source-specific notes
+
+- **ZINC** – Generate a tranche wget script from [CartBlanche](https://cartblanche.docking.org/tranches/2d) and save it as `data/ZINC22-downloader-2D-smi.gz.wget`. The ZINC connector parses this script, expecting the referenced `.smi.gz` archives to exist under `data/raw/zinc22/` (or it can download them automatically by setting `download_missing: true`). Each SMILES line should be formatted as `<SMILES>\t<ZINC_ID>`; additional columns are preserved as metadata.
+- **PubChem** – The default configuration downloads SDF bundles from the public FTP endpoint (`ftp.ncbi.nlm.nih.gov`) using anonymous credentials. Ensure outbound FTP access is permitted in your environment or mirror the SDF bundles locally and update the connector options accordingly.
+
 ## Continuous Integration
 The repository ships with a GitHub Actions workflow (`.github/workflows/ci.yml`) that installs dependencies via `uv`, runs linting, type checking, and executes the test suite to ensure changes remain healthy.
 

--- a/config/ingestion-example.yaml
+++ b/config/ingestion-example.yaml
@@ -16,9 +16,6 @@ job:
     - type: zinc
       name: zinc
       options:
-        base_url: https://example.test/zinc
-        endpoint: substances
-        records_path: [records]
-        next_cursor_path: [next]
-        id_field: zinc_id
-        smiles_field: smiles
+        wget_file: data/ZINC22-downloader-2D-smi.gz.wget
+        download_dir: data/raw/zinc22
+        download_missing: false

--- a/src/ingestion/zinc.py
+++ b/src/ingestion/zinc.py
@@ -1,30 +1,8 @@
-"""ZINC database ingestion connector."""
+"""Compatibility layer for importing ZINC ingestion components."""
 
 from __future__ import annotations
 
-from pydantic import Field
-
-from .common import BaseHttpConnector, HttpSourceConfig
-
-
-class ZincConfig(HttpSourceConfig):
-    """Configuration defaults for downloading from the ZINC database."""
-
-    base_url: str = "https://zinc15.docking.org"
-    endpoint: str = "substances.json"
-    batch_param: str = "limit"
-    cursor_param: str | None = "offset"
-    records_path: list[str] = Field(default_factory=lambda: ["substances"])
-    next_cursor_path: list[str] = Field(default_factory=lambda: ["next"])
-    id_field: str = "zinc_id"
-    smiles_field: str = "smiles"
-    metadata_fields: list[str] = Field(default_factory=lambda: ["mwt", "logp", "reactivity"])
-
-
-class ZincConnector(BaseHttpConnector):
-    """Connector for paginated SMILES ingestion from ZINC."""
-
-    config: ZincConfig
-
+from open_molecule_data_pipeline.ingestion.zinc import ZincConfig, ZincConnector
 
 __all__ = ["ZincConfig", "ZincConnector"]
+

--- a/src/open_molecule_data_pipeline/ingestion/zinc.py
+++ b/src/open_molecule_data_pipeline/ingestion/zinc.py
@@ -1,30 +1,308 @@
-"""ZINC database ingestion connector."""
+"""ZINC database ingestion via tranche download scripts."""
 
 from __future__ import annotations
 
+import gzip
+import shlex
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterator
+
+import httpx
+import structlog
 from pydantic import Field
 
-from .common import BaseHttpConnector, HttpSourceConfig
+from .common import (
+    BaseConnector,
+    CheckpointManager,
+    IngestionPage,
+    MoleculeRecord,
+    SourceConfig,
+)
+
+logger = structlog.get_logger(__name__)
 
 
-class ZincConfig(HttpSourceConfig):
-    """Configuration defaults for downloading from the ZINC database."""
+@dataclass(frozen=True)
+class _WgetCommand:
+    """Parsed representation of a single wget download command."""
 
-    base_url: str = "https://zinc15.docking.org"
-    endpoint: str = "substances.json"
-    batch_param: str = "limit"
-    cursor_param: str | None = "offset"
-    records_path: list[str] = Field(default_factory=lambda: ["substances"])
-    next_cursor_path: list[str] = Field(default_factory=lambda: ["next"])
-    id_field: str = "zinc_id"
-    smiles_field: str = "smiles"
-    metadata_fields: list[str] = Field(default_factory=lambda: ["mwt", "logp", "reactivity"])
+    url: str
+    output_path: Path
+    username: str | None
+    password: str | None
 
 
-class ZincConnector(BaseHttpConnector):
-    """Connector for paginated SMILES ingestion from ZINC."""
+class ZincConfig(SourceConfig):
+    """Configuration for ingesting ZINC tranche downloads."""
+
+    wget_file: Path = Field(description="Path to the generated wget script." )
+    download_dir: Path | None = Field(
+        default=None,
+        description="Directory containing downloaded tranche archives.",
+    )
+    download_missing: bool = Field(
+        default=False,
+        description=(
+            "If True, missing tranche archives will be downloaded automatically "
+            "using the URLs in the wget script."
+        ),
+    )
+    username: str | None = Field(
+        default=None,
+        description="Optional username for authenticated downloads.",
+    )
+    password: str | None = Field(
+        default=None,
+        description="Optional password for authenticated downloads.",
+    )
+    delimiter: str | None = Field(
+        default="\t",
+        description="Column delimiter in decompressed SMILES files.",
+    )
+    smiles_column: int = Field(
+        default=0,
+        ge=0,
+        description="Index of the SMILES column in tranche files.",
+    )
+    identifier_column: int = Field(
+        default=1,
+        ge=0,
+        description="Index of the identifier column in tranche files.",
+    )
+
+
+class ZincConnector(BaseConnector):
+    """Connector that streams SMILES from ZINC tranche downloads."""
 
     config: ZincConfig
 
+    def __init__(
+        self,
+        config: ZincConfig,
+        checkpoint_manager: CheckpointManager,
+    ) -> None:
+        super().__init__(config=config, checkpoint_manager=checkpoint_manager)
+        self._download_dir = self._resolve_download_dir()
+        self._commands = self._parse_wget_file(config.wget_file)
+
+    def _resolve_download_dir(self) -> Path:
+        if self.config.download_dir is not None:
+            return self.config.download_dir
+        return self.config.wget_file.resolve().parent
+
+    def _parse_wget_file(self, path: Path) -> list[_WgetCommand]:
+        if not path.exists():
+            raise FileNotFoundError(f"wget script not found: {path}")
+
+        commands: list[_WgetCommand] = []
+        for line_number, raw_line in enumerate(path.read_text().splitlines(), start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            for segment in line.split("&&"):
+                command = segment.strip()
+                if not command:
+                    continue
+                tokens = shlex.split(command)
+                if not tokens or tokens[0] != "wget":
+                    continue
+                parsed = self._parse_wget_tokens(tokens, line_number)
+                commands.append(parsed)
+
+        if not commands:
+            raise ValueError(f"No wget commands found in script: {path}")
+        return commands
+
+    def _normalise_output_path(self, raw: str, line_number: int) -> Path:
+        """Convert wget output targets to platform-agnostic paths."""
+
+        normalised = raw.replace("\\", "/")
+        pure_path = PurePosixPath(normalised)
+        if not pure_path.parts:
+            raise ValueError(
+                "Invalid wget command on line "
+                f"{line_number}: empty output path"
+            )
+        return Path(*pure_path.parts)
+
+    def _parse_wget_tokens(self, tokens: list[str], line_number: int) -> _WgetCommand:
+        url: str | None = None
+        output: Path | None = None
+        username = self.config.username
+        password = self.config.password
+
+        index = 1
+        while index < len(tokens):
+            token = tokens[index]
+            if token == "--user":
+                index += 1
+                if index < len(tokens):
+                    username = tokens[index]
+                index += 1
+                continue
+            if token == "--password":
+                index += 1
+                if index < len(tokens):
+                    password = tokens[index]
+                index += 1
+                continue
+            if token in {"-O", "--output-document"}:
+                index += 1
+                if index < len(tokens):
+                    output = self._normalise_output_path(tokens[index], line_number)
+                index += 1
+                continue
+            if token.startswith("-"):
+                index += 1
+                continue
+            if url is None:
+                url = token
+            index += 1
+
+        if url is None or output is None:
+            raise ValueError(
+                f"Invalid wget command on line {line_number}: {' '.join(tokens)}"
+            )
+
+        return _WgetCommand(url=url, output_path=output, username=username, password=password)
+
+    def _ensure_archive(self, command: _WgetCommand) -> Path:
+        target_path = self._download_dir / command.output_path
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        if target_path.exists():
+            return target_path
+
+        if not self.config.download_missing:
+            raise FileNotFoundError(
+                f"Required tranche archive is missing: {target_path}. "
+                "Set download_missing=True to fetch automatically."
+            )
+
+        logger.info(
+            "ingestion.zinc.download",
+            source=self.config.name,
+            url=command.url,
+            output=str(target_path),
+        )
+        auth: tuple[str, str] | None = None
+        if command.username and command.password:
+            auth = (command.username, command.password)
+        with httpx.stream("GET", command.url, auth=auth, timeout=60.0) as response:
+            response.raise_for_status()
+            with target_path.open("wb") as handle:
+                for chunk in response.iter_bytes():
+                    handle.write(chunk)
+        return target_path
+
+    def _iter_records(self, command: _WgetCommand) -> Iterator[MoleculeRecord]:
+        archive_path = self._ensure_archive(command)
+        delimiter = self.config.delimiter
+        smiles_index = self.config.smiles_column
+        identifier_index = self.config.identifier_column
+
+        with gzip.open(archive_path, "rt", encoding="utf-8", errors="replace") as stream:
+            for line_number, raw_line in enumerate(stream, start=1):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                parts = line.split(delimiter) if delimiter else line.split()
+                if (
+                    len(parts) <= max(smiles_index, identifier_index)
+                    or not parts[smiles_index]
+                    or not parts[identifier_index]
+                ):
+                    logger.debug(
+                        "ingestion.zinc.skip_line",
+                        source=self.config.name,
+                        file=str(command.output_path),
+                        line=line_number,
+                    )
+                    continue
+
+                smiles = parts[smiles_index].strip()
+                identifier = parts[identifier_index].strip()
+                metadata = {
+                    "source_file": command.output_path.as_posix(),
+                    "download_url": command.url,
+                }
+                for idx, value in enumerate(parts):
+                    if idx in {smiles_index, identifier_index}:
+                        continue
+                    key = f"column_{idx}"
+                    metadata[key] = value.strip()
+
+                yield MoleculeRecord(
+                    source=self.config.name,
+                    identifier=identifier,
+                    smiles=smiles,
+                    metadata=metadata,
+                )
+
+    def fetch_pages(self) -> Iterator[IngestionPage]:
+        checkpoint = self._checkpoint_manager.load(self.config.name)
+        if checkpoint and checkpoint.completed:
+            logger.info("ingestion.skip", source=self.config.name, reason="completed")
+            return
+
+        start_entry = 0
+        start_offset = 0
+        if checkpoint:
+            start_entry = int(checkpoint.cursor.get("entry_index", 0))
+            start_offset = int(checkpoint.cursor.get("line_offset", 0))
+
+        batch: list[MoleculeRecord] = []
+        commands = self._commands
+        for command_index in range(start_entry, len(commands)):
+            command = commands[command_index]
+            line_offset = start_offset if command_index == start_entry else 0
+            processed_lines = 0
+
+            for record in self._iter_records(command):
+                if processed_lines < line_offset:
+                    processed_lines += 1
+                    continue
+
+                batch.append(record)
+                processed_lines += 1
+                if len(batch) >= self.config.batch_size:
+                    next_cursor = {
+                        "entry_index": command_index,
+                        "line_offset": processed_lines,
+                        "file": command.output_path.as_posix(),
+                    }
+                    yield IngestionPage(records=list(batch), next_cursor=next_cursor)
+                    batch.clear()
+
+            if line_offset and processed_lines < line_offset:
+                logger.warning(
+                    "ingestion.zinc.offset_exceeds_file",
+                    source=self.config.name,
+                    file=command.output_path.as_posix(),
+                    expected_offset=line_offset,
+                    available_records=processed_lines,
+                )
+                line_offset = processed_lines
+
+            start_offset = 0
+
+            next_cursor: dict[str, int] | None
+            if batch:
+                if command_index + 1 < len(commands):
+                    next_cursor = {"entry_index": command_index + 1, "line_offset": 0}
+                else:
+                    next_cursor = None
+                yield IngestionPage(records=list(batch), next_cursor=next_cursor)
+                batch.clear()
+            elif processed_lines == 0:
+                if command_index + 1 < len(commands):
+                    next_cursor = {"entry_index": command_index + 1, "line_offset": 0}
+                else:
+                    next_cursor = None
+                yield IngestionPage(records=[], next_cursor=next_cursor)
+
+        if not commands:
+            yield IngestionPage(records=[], next_cursor=None)
 
 __all__ = ["ZincConfig", "ZincConnector"]
+

--- a/tests/unit/ingestion/test_zinc.py
+++ b/tests/unit/ingestion/test_zinc.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+
+import pytest
+
+from ingestion.common import CheckpointManager, IngestionCheckpoint
+from ingestion.zinc import ZincConfig, ZincConnector
+
+
+def _write_gzip_lines(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt", encoding="utf-8") as handle:
+        for line in lines:
+            handle.write(line)
+            handle.write("\n")
+
+
+def _create_wget_script(path: Path, relative_path: str) -> None:
+    path.write_text(
+        "mkdir -pv H04 && wget https://files.docking.org/zinc22/2d/H04/H04M000.smi.gz"
+        f" -O {relative_path}\n"
+    )
+
+
+def test_fetch_pages_from_wget_script(tmp_path: Path) -> None:
+    download_dir = tmp_path / "downloads"
+    archive_path = download_dir / "H04" / "H04M000.smi.gz"
+    _write_gzip_lines(
+        archive_path,
+        [
+            "C\tZINC00000001",
+            "CC\tZINC00000002",
+            "CCC\tZINC00000003",
+        ],
+    )
+
+    script_path = tmp_path / "zinc.wget"
+    _create_wget_script(script_path, "H04/H04M000.smi.gz")
+
+    config = ZincConfig(
+        name="zinc",
+        wget_file=script_path,
+        download_dir=download_dir,
+        batch_size=2,
+    )
+    checkpoint_manager = CheckpointManager(tmp_path / "checkpoints")
+    connector = ZincConnector(config=config, checkpoint_manager=checkpoint_manager)
+
+    pages = list(connector.fetch_pages())
+
+    assert len(pages) == 2
+    first_page, second_page = pages
+
+    assert len(first_page.records) == 2
+    assert first_page.records[0].identifier == "ZINC00000001"
+    assert first_page.records[0].smiles == "C"
+    assert first_page.records[0].metadata["source_file"] == "H04/H04M000.smi.gz"
+
+    assert len(second_page.records) == 1
+    assert second_page.next_cursor is None
+
+
+def test_fetch_pages_respects_checkpoint(tmp_path: Path) -> None:
+    download_dir = tmp_path / "downloads"
+    archive_path = download_dir / "H04" / "H04M000.smi.gz"
+    _write_gzip_lines(
+        archive_path,
+        [
+            "C\tZINC00000001",
+            "CC\tZINC00000002",
+            "CCC\tZINC00000003",
+        ],
+    )
+
+    script_path = tmp_path / "zinc.wget"
+    _create_wget_script(script_path, "H04/H04M000.smi.gz")
+
+    config = ZincConfig(
+        name="zinc",
+        wget_file=script_path,
+        download_dir=download_dir,
+        batch_size=2,
+    )
+    checkpoint_manager = CheckpointManager(tmp_path / "checkpoints")
+    checkpoint_manager.store(
+        "zinc",
+        IngestionCheckpoint(cursor={"entry_index": 0, "line_offset": 2}, batch_index=1),
+    )
+
+    connector = ZincConnector(config=config, checkpoint_manager=checkpoint_manager)
+    pages = list(connector.fetch_pages())
+
+    assert len(pages) == 1
+    assert len(pages[0].records) == 1
+    assert pages[0].records[0].identifier == "ZINC00000003"
+
+
+def test_missing_archive_raises_without_download(tmp_path: Path) -> None:
+    download_dir = tmp_path / "downloads"
+    script_path = tmp_path / "zinc.wget"
+    _create_wget_script(script_path, "H04/H04M000.smi.gz")
+
+    config = ZincConfig(
+        name="zinc",
+        wget_file=script_path,
+        download_dir=download_dir,
+    )
+    checkpoint_manager = CheckpointManager(tmp_path / "checkpoints")
+    connector = ZincConnector(config=config, checkpoint_manager=checkpoint_manager)
+
+    with pytest.raises(FileNotFoundError):
+        list(connector.fetch_pages())


### PR DESCRIPTION
## Summary
- normalize wget output paths so tranche archives resolve correctly on any platform
- emit tranche file metadata and cursors using POSIX separators for consistent downstream handling

## Testing
- uv run --extra dev pytest tests/unit/ingestion/test_zinc.py

------
https://chatgpt.com/codex/tasks/task_e_68da49f6ceb483219715848d968b5c56