### PR TITLE
Refactor PubChem ingestion to use HTTPS downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Each source writes gzip-compressed NDJSON batches to `data/raw/<source>/` and ma
 ### Source-specific notes
 
 - **ZINC** – Generate a tranche wget script from [CartBlanche](https://cartblanche.docking.org/tranches/2d) and save it as `data/ZINC22-downloader-2D-smi.gz.wget`. The ZINC connector parses this script, expecting the referenced `.smi.gz` archives to exist under `data/raw/zinc22/` (or it can download them automatically by setting `download_missing: true`). Each SMILES line should be formatted as `<SMILES>\t<ZINC_ID>`; additional columns are preserved as metadata.
-- **PubChem** – The default configuration downloads SDF bundles from the public FTP endpoint (`ftp.ncbi.nlm.nih.gov`) using anonymous credentials. Ensure outbound FTP access is permitted in your environment or mirror the SDF bundles locally and update the connector options accordingly.
+- **PubChem** – The connector enumerates SDF bundles from the public HTTPS directory listing at [`https://ftp.ncbi.nlm.nih.gov/pubchem/Compound/CURRENT-Full/SDF/`](https://ftp.ncbi.nlm.nih.gov/pubchem/Compound/CURRENT-Full/SDF/). Ensure outbound HTTPS access is permitted or mirror the SDF bundles locally and override the `base_url` in the connector configuration to point at your mirror.
 
 ## Continuous Integration
 The repository ships with a GitHub Actions workflow (`.github/workflows/ci.yml`) that installs dependencies via `uv`, runs linting, type checking, and executes the test suite to ensure changes remain healthy.

--- a/src/ingestion/pubchem.py
+++ b/src/ingestion/pubchem.py
@@ -3,30 +3,65 @@
 from __future__ import annotations
 
 import contextlib
-import ftplib
 import gzip
-from collections.abc import Callable, Iterable, Iterator, Mapping
-from pathlib import Path
 import tempfile
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from html.parser import HTMLParser
+from pathlib import Path
 from typing import Any
+from urllib.parse import urljoin
 
+import httpx
 import structlog
 from pydantic import Field
 
-from .common import BaseConnector, CheckpointManager, IngestionPage, MoleculeRecord, SourceConfig
+from .common import (
+    BaseConnector,
+    CheckpointManager,
+    IngestionPage,
+    MoleculeRecord,
+    SourceConfig,
+    DEFAULT_USER_AGENT,
+    execute_request,
+)
 
 logger = structlog.get_logger(__name__)
 
 
-class PubChemConfig(SourceConfig):
-    """Configuration for downloading PubChem SDF bundles over FTP."""
+class _DirectoryListingParser(HTMLParser):
+    """Extract file names from an HTML directory index."""
 
-    ftp_host: str = "ftp.ncbi.nlm.nih.gov"
-    ftp_port: int = 21
-    ftp_directory: str = "pubchem/Compound/CURRENT-Full/SDF"
-    ftp_username: str = "anonymous"
-    ftp_password: str = "anonymous@"
-    passive_mode: bool = True
+    def __init__(self, suffixes: Iterable[str]) -> None:
+        super().__init__()
+        self._suffixes = tuple(suffixes)
+        self._filenames: set[str] = set()
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str]]) -> None:
+        if tag.lower() != "a":
+            return
+        href = None
+        for key, value in attrs:
+            if key.lower() == "href":
+                href = value
+                break
+        if not href:
+            return
+        candidate = href.split("#", 1)[0].split("?", 1)[0].strip()
+        if not candidate or not candidate.endswith(self._suffixes):
+            return
+        # Directory listings sometimes include relative paths; keep the base name.
+        filename = candidate.rsplit("/", 1)[-1]
+        if filename:
+            self._filenames.add(filename)
+
+    def get_filenames(self) -> list[str]:
+        return sorted(self._filenames)
+
+
+class PubChemConfig(SourceConfig):
+    """Configuration for downloading PubChem SDF bundles over HTTPS."""
+
+    base_url: str = "https://ftp.ncbi.nlm.nih.gov/pubchem/Compound/CURRENT-Full/SDF/"
     timeout: float = 60.0
     file_suffixes: list[str] = Field(default_factory=lambda: [".sdf.gz", ".sdf"])
     identifier_tag: str = "PUBCHEM_COMPOUND_CID"
@@ -35,7 +70,7 @@ class PubChemConfig(SourceConfig):
 
 
 class PubChemConnector(BaseConnector):
-    """Connector that downloads and parses PubChem SDF archives via FTP."""
+    """Connector that downloads and parses PubChem SDF archives via HTTPS."""
 
     config: PubChemConfig
 
@@ -43,45 +78,51 @@ class PubChemConnector(BaseConnector):
         self,
         config: PubChemConfig,
         checkpoint_manager: CheckpointManager,
-        ftp_factory: Callable[[], ftplib.FTP] | None = None,
+        client_factory: Callable[[], httpx.Client] | None = None,
     ) -> None:
         super().__init__(config=config, checkpoint_manager=checkpoint_manager)
-        self._ftp_factory = ftp_factory or self._create_default_ftp
-        self._ftp: ftplib.FTP | None = None
+        self._client_factory = client_factory or self._create_default_client
+        self._client: httpx.Client | None = None
 
-    def _create_default_ftp(self) -> ftplib.FTP:
-        ftp = ftplib.FTP()
-        ftp.connect(self.config.ftp_host, self.config.ftp_port, timeout=self.config.timeout)
-        ftp.login(self.config.ftp_username, self.config.ftp_password)
-        ftp.set_pasv(self.config.passive_mode)
-        ftp.cwd(self.config.ftp_directory)
-        return ftp
+    def _create_default_client(self) -> httpx.Client:
+        return httpx.Client(
+            timeout=self.config.timeout,
+            headers={"User-Agent": DEFAULT_USER_AGENT},
+            follow_redirects=True,
+        )
 
-    def _ensure_ftp(self) -> ftplib.FTP:
-        if self._ftp is None:
-            ftp = self._ftp_factory()
-            try:
-                ftp.cwd(self.config.ftp_directory)
-            except ftplib.all_errors:
-                # Directory might already be set by the factory; ignore errors to avoid
-                # breaking custom factories in tests.
-                pass
-            self._ftp = ftp
-        return self._ftp
+    def _ensure_client(self) -> httpx.Client:
+        if self._client is None:
+            self._client = self._client_factory()
+        return self._client
 
-    def _list_remote_files(self, ftp: ftplib.FTP) -> list[str]:
-        names = ftp.nlst()
-        suffixes = tuple(self.config.file_suffixes)
-        if suffixes:
-            names = [name for name in names if name.endswith(suffixes)]
-        return sorted(names)
+    def _list_remote_files(self, client: httpx.Client) -> list[str]:
+        request = client.build_request("GET", self.config.base_url)
+        response = execute_request(client, request)
+        try:
+            parser = _DirectoryListingParser(self.config.file_suffixes)
+            parser.feed(response.text)
+            parser.close()
+            return parser.get_filenames()
+        finally:
+            response.close()
 
     @contextlib.contextmanager
-    def _download_file(self, ftp: ftplib.FTP, filename: str) -> Iterator[Path]:
-        suffix = Path(filename).suffix
-        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
-            ftp.retrbinary(f"RETR {filename}", handle.write)
-            temp_path = Path(handle.name)
+    def _download_file(self, client: httpx.Client, filename: str) -> Iterator[Path]:
+        url = urljoin(self.config.base_url, filename)
+        request = client.build_request("GET", url)
+        response = execute_request(client, request)
+        temp_path: Path | None = None
+        try:
+            suffix = Path(filename).suffix
+            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+                temp_path = Path(handle.name)
+                for chunk in response.iter_bytes():
+                    handle.write(chunk)
+        finally:
+            response.close()
+
+        assert temp_path is not None  # pragma: no cover - defensive guard
         try:
             yield temp_path
         finally:
@@ -120,8 +161,8 @@ class PubChemConnector(BaseConnector):
             properties[current_tag] = "\n".join(buffer).strip()
         return properties
 
-    def _iter_sdf_entries(self, ftp: ftplib.FTP, filename: str) -> Iterator[dict[str, str]]:
-        with self._download_file(ftp, filename) as temp_path:
+    def _iter_sdf_entries(self, client: httpx.Client, filename: str) -> Iterator[dict[str, str]]:
+        with self._download_file(client, filename) as temp_path:
             with self._open_sdf_stream(temp_path) as stream:
                 entry_lines: list[str] = []
                 for raw_line in stream:
@@ -163,8 +204,8 @@ class PubChemConnector(BaseConnector):
             logger.info("ingestion.skip", source=self.config.name, reason="completed")
             return
 
-        ftp = self._ensure_ftp()
-        filenames = self._list_remote_files(ftp)
+        client = self._ensure_client()
+        filenames = self._list_remote_files(client)
 
         start_file = 0
         start_offset = 0
@@ -185,7 +226,7 @@ class PubChemConnector(BaseConnector):
             filename = filenames[current_file]
             logger.info("ingestion.pubchem.file", source=self.config.name, file=filename)
             entry_index = 0
-            for entry in self._iter_sdf_entries(ftp, filename):
+            for entry in self._iter_sdf_entries(client, filename):
                 if entry_index < current_offset:
                     entry_index += 1
                     continue
@@ -223,11 +264,11 @@ class PubChemConnector(BaseConnector):
             yield IngestionPage(records=[], next_cursor=None)
 
     def close(self) -> None:
-        if self._ftp is None:
+        if self._client is None:
             return
         with contextlib.suppress(Exception):
-            self._ftp.quit()
-        self._ftp = None
+            self._client.close()
+        self._client = None
 
 
 __all__ = ["PubChemConfig", "PubChemConnector"]

--- a/src/ingestion/runner.py
+++ b/src/ingestion/runner.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import inspect
+
 import httpx
 import structlog
 import yaml
@@ -113,11 +115,12 @@ def _build_connector(
         "config": config,
         "checkpoint_manager": checkpoint_manager,
     }
-    if issubclass(connector_cls, BaseHttpConnector):
-        if client_factory is not None:
+    if client_factory is not None:
+        signature = inspect.signature(connector_cls.__init__)
+        if "client_factory" in signature.parameters:
             kwargs["client_factory"] = client_factory
-    elif client_factory is not None:
-        kwargs["ftp_factory"] = client_factory
+        elif "ftp_factory" in signature.parameters:
+            kwargs["ftp_factory"] = client_factory
     return connector_cls(**kwargs)  # type: ignore[arg-type]
 
 

--- a/src/open_molecule_data_pipeline/ingestion/pubchem.py
+++ b/src/open_molecule_data_pipeline/ingestion/pubchem.py
@@ -3,30 +3,65 @@
 from __future__ import annotations
 
 import contextlib
-import ftplib
 import gzip
-from collections.abc import Callable, Iterable, Iterator, Mapping
-from pathlib import Path
 import tempfile
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from html.parser import HTMLParser
+from pathlib import Path
 from typing import Any
+from urllib.parse import urljoin
 
+import httpx
 import structlog
 from pydantic import Field
 
-from .common import BaseConnector, CheckpointManager, IngestionPage, MoleculeRecord, SourceConfig
+from .common import (
+    BaseConnector,
+    CheckpointManager,
+    IngestionPage,
+    MoleculeRecord,
+    SourceConfig,
+    DEFAULT_USER_AGENT,
+    execute_request,
+)
 
 logger = structlog.get_logger(__name__)
 
 
-class PubChemConfig(SourceConfig):
-    """Configuration for downloading PubChem SDF bundles over FTP."""
+class _DirectoryListingParser(HTMLParser):
+    """Extract file names from an HTML directory index."""
 
-    ftp_host: str = "ftp.ncbi.nlm.nih.gov"
-    ftp_port: int = 21
-    ftp_directory: str = "pubchem/Compound/CURRENT-Full/SDF"
-    ftp_username: str = "anonymous"
-    ftp_password: str = "anonymous@"
-    passive_mode: bool = True
+    def __init__(self, suffixes: Iterable[str]) -> None:
+        super().__init__()
+        self._suffixes = tuple(suffixes)
+        self._filenames: set[str] = set()
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str]]) -> None:
+        if tag.lower() != "a":
+            return
+        href = None
+        for key, value in attrs:
+            if key.lower() == "href":
+                href = value
+                break
+        if not href:
+            return
+        candidate = href.split("#", 1)[0].split("?", 1)[0].strip()
+        if not candidate or not candidate.endswith(self._suffixes):
+            return
+        # Directory listings sometimes include relative paths; keep the base name.
+        filename = candidate.rsplit("/", 1)[-1]
+        if filename:
+            self._filenames.add(filename)
+
+    def get_filenames(self) -> list[str]:
+        return sorted(self._filenames)
+
+
+class PubChemConfig(SourceConfig):
+    """Configuration for downloading PubChem SDF bundles over HTTPS."""
+
+    base_url: str = "https://ftp.ncbi.nlm.nih.gov/pubchem/Compound/CURRENT-Full/SDF/"
     timeout: float = 60.0
     file_suffixes: list[str] = Field(default_factory=lambda: [".sdf.gz", ".sdf"])
     identifier_tag: str = "PUBCHEM_COMPOUND_CID"
@@ -35,7 +70,7 @@ class PubChemConfig(SourceConfig):
 
 
 class PubChemConnector(BaseConnector):
-    """Connector that downloads and parses PubChem SDF archives via FTP."""
+    """Connector that downloads and parses PubChem SDF archives via HTTPS."""
 
     config: PubChemConfig
 
@@ -43,45 +78,51 @@ class PubChemConnector(BaseConnector):
         self,
         config: PubChemConfig,
         checkpoint_manager: CheckpointManager,
-        ftp_factory: Callable[[], ftplib.FTP] | None = None,
+        client_factory: Callable[[], httpx.Client] | None = None,
     ) -> None:
         super().__init__(config=config, checkpoint_manager=checkpoint_manager)
-        self._ftp_factory = ftp_factory or self._create_default_ftp
-        self._ftp: ftplib.FTP | None = None
+        self._client_factory = client_factory or self._create_default_client
+        self._client: httpx.Client | None = None
 
-    def _create_default_ftp(self) -> ftplib.FTP:
-        ftp = ftplib.FTP()
-        ftp.connect(self.config.ftp_host, self.config.ftp_port, timeout=self.config.timeout)
-        ftp.login(self.config.ftp_username, self.config.ftp_password)
-        ftp.set_pasv(self.config.passive_mode)
-        ftp.cwd(self.config.ftp_directory)
-        return ftp
+    def _create_default_client(self) -> httpx.Client:
+        return httpx.Client(
+            timeout=self.config.timeout,
+            headers={"User-Agent": DEFAULT_USER_AGENT},
+            follow_redirects=True,
+        )
 
-    def _ensure_ftp(self) -> ftplib.FTP:
-        if self._ftp is None:
-            ftp = self._ftp_factory()
-            try:
-                ftp.cwd(self.config.ftp_directory)
-            except ftplib.all_errors:
-                # Directory might already be set by the factory; ignore errors to avoid
-                # breaking custom factories in tests.
-                pass
-            self._ftp = ftp
-        return self._ftp
+    def _ensure_client(self) -> httpx.Client:
+        if self._client is None:
+            self._client = self._client_factory()
+        return self._client
 
-    def _list_remote_files(self, ftp: ftplib.FTP) -> list[str]:
-        names = ftp.nlst()
-        suffixes = tuple(self.config.file_suffixes)
-        if suffixes:
-            names = [name for name in names if name.endswith(suffixes)]
-        return sorted(names)
+    def _list_remote_files(self, client: httpx.Client) -> list[str]:
+        request = client.build_request("GET", self.config.base_url)
+        response = execute_request(client, request)
+        try:
+            parser = _DirectoryListingParser(self.config.file_suffixes)
+            parser.feed(response.text)
+            parser.close()
+            return parser.get_filenames()
+        finally:
+            response.close()
 
     @contextlib.contextmanager
-    def _download_file(self, ftp: ftplib.FTP, filename: str) -> Iterator[Path]:
-        suffix = Path(filename).suffix
-        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
-            ftp.retrbinary(f"RETR {filename}", handle.write)
-            temp_path = Path(handle.name)
+    def _download_file(self, client: httpx.Client, filename: str) -> Iterator[Path]:
+        url = urljoin(self.config.base_url, filename)
+        request = client.build_request("GET", url)
+        response = execute_request(client, request)
+        temp_path: Path | None = None
+        try:
+            suffix = Path(filename).suffix
+            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+                temp_path = Path(handle.name)
+                for chunk in response.iter_bytes():
+                    handle.write(chunk)
+        finally:
+            response.close()
+
+        assert temp_path is not None  # pragma: no cover - defensive guard
         try:
             yield temp_path
         finally:
@@ -120,8 +161,8 @@ class PubChemConnector(BaseConnector):
             properties[current_tag] = "\n".join(buffer).strip()
         return properties
 
-    def _iter_sdf_entries(self, ftp: ftplib.FTP, filename: str) -> Iterator[dict[str, str]]:
-        with self._download_file(ftp, filename) as temp_path:
+    def _iter_sdf_entries(self, client: httpx.Client, filename: str) -> Iterator[dict[str, str]]:
+        with self._download_file(client, filename) as temp_path:
             with self._open_sdf_stream(temp_path) as stream:
                 entry_lines: list[str] = []
                 for raw_line in stream:
@@ -163,8 +204,8 @@ class PubChemConnector(BaseConnector):
             logger.info("ingestion.skip", source=self.config.name, reason="completed")
             return
 
-        ftp = self._ensure_ftp()
-        filenames = self._list_remote_files(ftp)
+        client = self._ensure_client()
+        filenames = self._list_remote_files(client)
 
         start_file = 0
         start_offset = 0
@@ -185,7 +226,7 @@ class PubChemConnector(BaseConnector):
             filename = filenames[current_file]
             logger.info("ingestion.pubchem.file", source=self.config.name, file=filename)
             entry_index = 0
-            for entry in self._iter_sdf_entries(ftp, filename):
+            for entry in self._iter_sdf_entries(client, filename):
                 if entry_index < current_offset:
                     entry_index += 1
                     continue
@@ -223,11 +264,11 @@ class PubChemConnector(BaseConnector):
             yield IngestionPage(records=[], next_cursor=None)
 
     def close(self) -> None:
-        if self._ftp is None:
+        if self._client is None:
             return
         with contextlib.suppress(Exception):
-            self._ftp.quit()
-        self._ftp = None
+            self._client.close()
+        self._client = None
 
 
 __all__ = ["PubChemConfig", "PubChemConnector"]

--- a/src/open_molecule_data_pipeline/ingestion/runner.py
+++ b/src/open_molecule_data_pipeline/ingestion/runner.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import inspect
+
 import httpx
 import structlog
 import yaml
@@ -113,11 +115,12 @@ def _build_connector(
         "config": config,
         "checkpoint_manager": checkpoint_manager,
     }
-    if issubclass(connector_cls, BaseHttpConnector):
-        if client_factory is not None:
+    if client_factory is not None:
+        signature = inspect.signature(connector_cls.__init__)
+        if "client_factory" in signature.parameters:
             kwargs["client_factory"] = client_factory
-    elif client_factory is not None:
-        kwargs["ftp_factory"] = client_factory
+        elif "ftp_factory" in signature.parameters:
+            kwargs["ftp_factory"] = client_factory
     return connector_cls(**kwargs)  # type: ignore[arg-type]
 
 

--- a/tests/unit/ingestion/test_runner.py
+++ b/tests/unit/ingestion/test_runner.py
@@ -5,31 +5,13 @@ import io
 import json
 from pathlib import Path
 
+import httpx
+
 from open_molecule_data_pipeline.ingestion.runner import (
     IngestionJobConfig,
     SourceDefinition,
     run_ingestion,
 )
-
-
-class FakeFTP:
-    def __init__(self, files: dict[str, bytes], calls: dict[str, int]) -> None:
-        self._files = files
-        self._calls = calls
-
-    def cwd(self, path: str) -> None:  # noqa: D401 - required by ftplib interface
-        self._cwd = path
-
-    def nlst(self) -> list[str]:
-        return sorted(self._files)
-
-    def retrbinary(self, cmd: str, callback) -> None:
-        self._calls["retr"] = self._calls.get("retr", 0) + 1
-        _, filename = cmd.split(maxsplit=1)
-        callback(self._files[filename])
-
-    def quit(self) -> None:
-        self._calls["quit"] = self._calls.get("quit", 0) + 1
 
 
 def _gzip_bytes(payload: str) -> bytes:
@@ -59,12 +41,45 @@ def _sdf_entry(cid: str, smiles: str) -> str:
     )
 
 
+def _mock_pubchem_client(
+    files: dict[str, bytes], base_url: str, calls: dict[str, int]
+) -> httpx.Client:
+    base = httpx.URL(base_url)
+    listing_path = base.path
+    if not listing_path.endswith("/"):
+        listing_path = f"{listing_path}/"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["requests"] = calls.get("requests", 0) + 1
+        if request.method != "GET":  # pragma: no cover - defensive guard
+            return httpx.Response(405)
+
+        path = request.url.path
+        if path.rstrip("/") == listing_path.rstrip("/"):
+            links = "".join(
+                f'<a href="{name}">{name}</a>' for name in sorted(files)
+            )
+            return httpx.Response(200, text=f"<html><body>{links}</body></html>")
+
+        if not path.startswith(listing_path):
+            return httpx.Response(404)
+
+        filename = path[len(listing_path) :]
+        if filename not in files:
+            return httpx.Response(404)
+        return httpx.Response(200, content=files[filename])
+
+    transport = httpx.MockTransport(handler)
+    return httpx.Client(transport=transport, timeout=5.0)
+
+
 def test_run_ingestion_writes_batches_and_checkpoints(tmp_path: Path) -> None:
     files = {
         "chunk_a.sdf.gz": _gzip_bytes(_sdf_entry("CID1", "C") + _sdf_entry("CID2", "CC")),
         "chunk_b.sdf.gz": _gzip_bytes(_sdf_entry("CID3", "CCC")),
     }
     calls: dict[str, int] = {}
+    base_url = "https://example.test/pubchem/Compound/CURRENT-Full/SDF/"
 
     config = IngestionJobConfig(
         output_dir=tmp_path / "raw",
@@ -77,17 +92,17 @@ def test_run_ingestion_writes_batches_and_checkpoints(tmp_path: Path) -> None:
                 type="pubchem",
                 name="pubchem",
                 options={
-                    "ftp_directory": ".",
+                    "base_url": base_url,
                 },
             )
         ],
     )
 
-    def ftp_factory() -> FakeFTP:
+    def client_factory() -> httpx.Client:
         calls["factory"] = calls.get("factory", 0) + 1
-        return FakeFTP(files, calls)
+        return _mock_pubchem_client(files, base_url, calls)
 
-    run_ingestion(config, client_factories={"pubchem": ftp_factory})
+    run_ingestion(config, client_factories={"pubchem": client_factory})
 
     output_dir = tmp_path / "raw" / "pubchem"
     first_batch = output_dir / "pubchem-batch-000001.jsonl"
@@ -109,5 +124,5 @@ def test_run_ingestion_writes_batches_and_checkpoints(tmp_path: Path) -> None:
     assert checkpoint["batch_index"] == 2
     assert checkpoint["completed"] is True
 
-    run_ingestion(config, client_factories={"pubchem": ftp_factory})
+    run_ingestion(config, client_factories={"pubchem": client_factory})
     assert calls["factory"] == 1


### PR DESCRIPTION
## Summary
- replace the PubChem FTP client with an HTTPS directory scraper that streams SDF bundles via httpx
- adjust the ingestion runner and unit tests to work with HTTP client factories and update README guidance

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68da4fffabc083219bf87077bc614ebc