### PR TITLE
Refactor ingestion connectors to use aria2 downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A scalable toolkit for ingesting, processing, and analyzing large-scale collecti
 ### Prerequisites
 - Python 3.11+
 - [uv](https://github.com/astral-sh/uv) package manager installed and on your `PATH`.
+- [`aria2c`](https://aria2.github.io/) command-line downloader available for resumable transfers.
 
 ### Environment Setup
 ```bash
@@ -71,9 +72,9 @@ Each source writes gzip-compressed NDJSON batches to `data/raw/<source>/` and ma
 
 ### Source-specific notes
 
-- **ZINC** – Generate a tranche wget script from [CartBlanche](https://cartblanche.docking.org/tranches/2d) and save it as `data/ZINC22-downloader-2D-smi.gz.wget`. The ZINC connector parses this script, expecting the referenced `.smi.gz` archives to exist under `data/raw/zinc22/` (or it can download them automatically by setting `download_missing: true`). Each SMILES line should be formatted as `<SMILES>\t<ZINC_ID>`; additional columns are preserved as metadata.
-- **PubChem** – The connector enumerates SDF bundles from the public HTTPS directory listing at [`https://ftp.ncbi.nlm.nih.gov/pubchem/Compound/CURRENT-Full/SDF/`](https://ftp.ncbi.nlm.nih.gov/pubchem/Compound/CURRENT-Full/SDF/) and save it as `data/Index_of_pubchem_Compound_CURRENT-Full_SDF.html`. Ensure outbound HTTPS access is permitted or mirror the SDF bundles locally and override the `base_url` in the connector configuration to point at your mirror.
-- **chEMBL** - The latest ChEMBLdb sdf data is listed in https://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/latest/ , the sdf file download link are saved in `data/chEMBL_sdf_link.txt`.
+- **ZINC** – Generate a tranche wget script from [CartBlanche](https://cartblanche.docking.org/tranches/2d) and save it as `data/ZINC22-downloader-2D-smi.gz.wget`. The connector parses each `wget` invocation, extracts embedded credentials, and shells out to `aria2c` to fetch any missing tranche archives (resume and checksum support included). Existing `.smi.gz` archives are reused directly.
+- **PubChem** – Download the HTML directory index from [`https://ftp.ncbi.nlm.nih.gov/pubchem/Compound/CURRENT-Full/SDF/`](https://ftp.ncbi.nlm.nih.gov/pubchem/Compound/CURRENT-Full/SDF/) and store it as `data/Index_of_pubchem_Compound_CURRENT-Full_SDF.html`. The connector reads this index, matches each `.sdf.gz` link with its companion `.md5` checksum, and uses `aria2c` to download or resume the bundles into the configured cache directory before parsing.
+- **ChEMBL** – Record the bulk SDF URLs (one per line) in `data/chEMBL_sdf_link.txt`. Each archive is downloaded via `aria2c` (with resume) into the local cache prior to SMILES extraction. Default tag mappings expect `ChEMBL_ID` and `CANONICAL_SMILES`, but they can be overridden in the connector configuration.
 
 ## Continuous Integration
 The repository ships with a GitHub Actions workflow (`.github/workflows/ci.yml`) that installs dependencies via `uv`, runs linting, type checking, and executes the test suite to ensure changes remain healthy.

--- a/src/open_molecule_data_pipeline/__init__.py
+++ b/src/open_molecule_data_pipeline/__init__.py
@@ -1,11 +1,3 @@
 """Top-level package for the open molecule data pipeline."""
 
-from . import analysis, common, ingestion, pipeline, reporting
-
-__all__ = [
-    "analysis",
-    "common",
-    "ingestion",
-    "pipeline",
-    "reporting",
-]
+__all__ = ["analysis", "common", "ingestion", "pipeline", "reporting"]

--- a/src/open_molecule_data_pipeline/ingestion/aria2.py
+++ b/src/open_molecule_data_pipeline/ingestion/aria2.py
@@ -1,0 +1,113 @@
+"""Utilities for invoking :mod:`aria2c` as the unified download backend."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Sequence
+
+Runner = Callable[[Sequence[str]], object]
+
+
+@dataclass(frozen=True)
+class Aria2Options:
+    """Configuration options passed to :command:`aria2c`."""
+
+    connections: int = 16
+    split: int = 16
+    min_split_size: str = "1M"
+    max_tries: int = 5
+    retry_wait: int = 2
+    extra_args: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_args(self) -> list[str]:
+        """Return CLI arguments derived from the option values."""
+
+        args = [
+            f"--max-connection-per-server={self.connections}",
+            f"--split={self.split}",
+            f"--min-split-size={self.min_split_size}",
+            f"--max-tries={self.max_tries}",
+            f"--retry-wait={self.retry_wait}",
+        ]
+        args.extend(self.extra_args)
+        return args
+
+
+def _default_runner(command: Sequence[str]) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(command, check=True, capture_output=True)
+
+
+def download_with_aria2(
+    url: str,
+    output_path: Path,
+    *,
+    checksum: tuple[str, str] | None = None,
+    username: str | None = None,
+    password: str | None = None,
+    skip_existing: bool = True,
+    options: Aria2Options | None = None,
+    runner: Runner | None = None,
+) -> None:
+    """Download *url* to *output_path* using :command:`aria2c`.
+
+    Parameters
+    ----------
+    url:
+        HTTP or FTP URL pointing to the payload.
+    output_path:
+        Target path for the downloaded file. Parent directories are created as
+        needed.
+    checksum:
+        Optional tuple of ``(algorithm, value)`` passed to ``--checksum`` for
+        integrity verification.
+    username / password:
+        Optional HTTP basic authentication credentials.
+    skip_existing:
+        If ``True`` (the default) and *output_path* exists with a positive size
+        and no checksum validation is requested, the download is skipped.
+    options:
+        Advanced :class:`Aria2Options` controlling concurrency and retries.
+    runner:
+        Callable executing the constructed command. Defaults to
+        :func:`subprocess.run` with ``check=True`` and output capture so unit
+        tests can substitute their own implementation.
+    """
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if skip_existing and output_path.exists() and output_path.stat().st_size > 0 and checksum is None:
+        return
+
+    command: list[str] = [
+        "aria2c",
+        "--continue=true",
+        "--auto-file-renaming=false",
+        "--allow-overwrite=true",
+        f"--dir={output_path.parent}",
+        f"--out={output_path.name}",
+    ]
+
+    opts = options or Aria2Options()
+    command.extend(opts.to_args())
+
+    if checksum is not None:
+        algorithm, value = checksum
+        command.append(f"--checksum={algorithm}={value}")
+        command.append("--check-integrity=true")
+
+    if username:
+        command.extend(["--http-user", username])
+    if password:
+        command.extend(["--http-password", password])
+
+    command.append(url)
+
+    exec_runner = runner or _default_runner
+    exec_runner(command)
+
+
+__all__ = ["Aria2Options", "download_with_aria2"]
+

--- a/src/open_molecule_data_pipeline/ingestion/chembl.py
+++ b/src/open_molecule_data_pipeline/ingestion/chembl.py
@@ -1,32 +1,190 @@
-"""ChEMBL ingestion connector."""
+"""ChEMBL ingestion connector using bulk SDF downloads."""
 
 from __future__ import annotations
+"""ChEMBL ingestion connector using bulk SDF downloads."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterator, Mapping
 
 from pydantic import Field
 
-from .common import BaseHttpConnector, HttpSourceConfig
+from .aria2 import Aria2Options, download_with_aria2
+from .common import (
+    BaseConnector,
+    CheckpointManager,
+    IngestionPage,
+    MoleculeRecord,
+    SourceConfig,
+)
+from .sdf import iter_sdf_records
+from ..logging_utils import get_logger
+
+logger = get_logger(__name__)
 
 
-class ChEMBLConfig(HttpSourceConfig):
-    """Configuration defaults for the ChEMBL API."""
+@dataclass(frozen=True)
+class _ChEMBLEntry:
+    filename: str
+    url: str
 
-    base_url: str = "https://www.ebi.ac.uk"
-    endpoint: str = "chembl/api/data/molecule.json"
-    batch_param: str = "limit"
-    cursor_param: str | None = "offset"
-    records_path: list[str] = Field(default_factory=lambda: ["molecules"])
-    next_cursor_path: list[str] = Field(default_factory=lambda: ["page_meta", "next"])
-    id_field: str = "molecule_chembl_id"
-    smiles_field: str = "canonical_smiles"
-    metadata_fields: list[str] = Field(
-        default_factory=lambda: ["pref_name", "molecule_type", "molecular_weight"]
+
+class ChEMBLConfig(SourceConfig):
+    """Configuration for downloading ChEMBL SDF exports."""
+
+    link_file: Path = Field(description="Path to the file containing ChEMBL SDF URLs.")
+    download_dir: Path | None = Field(
+        default=None,
+        description="Directory where downloaded ChEMBL archives are stored.",
     )
+    identifier_tag: str = "ChEMBL_ID"
+    smiles_tag: str = "CANONICAL_SMILES"
+    metadata_tags: list[str] = Field(default_factory=list)
+    aria2_options: dict[str, str | int | float | bool] = Field(default_factory=dict)
 
 
-class ChEMBLConnector(BaseHttpConnector):
-    """Connector for ingesting SMILES data from ChEMBL."""
+class ChEMBLConnector(BaseConnector):
+    """Connector for ingesting SMILES data from bulk ChEMBL SDF archives."""
 
     config: ChEMBLConfig
+
+    def __init__(
+        self,
+        config: ChEMBLConfig,
+        checkpoint_manager: CheckpointManager,
+        aria2_downloader: Callable[..., None] | None = None,
+    ) -> None:
+        super().__init__(config=config, checkpoint_manager=checkpoint_manager)
+        self._download_dir = self._resolve_download_dir()
+        self._aria2_downloader = aria2_downloader or download_with_aria2
+        self._aria2_options = self._build_aria2_options()
+        self._entries = self._parse_link_file(config.link_file)
+
+    def _resolve_download_dir(self) -> Path:
+        if self.config.download_dir is not None:
+            return self.config.download_dir
+        return self.config.link_file.resolve().parent
+
+    def _build_aria2_options(self) -> Aria2Options:
+        options = self.config.aria2_options
+        if not options:
+            return Aria2Options()
+        try:
+            return Aria2Options(**options)
+        except TypeError as exc:  # pragma: no cover - defensive guard
+            raise ValueError("Invalid aria2 options supplied") from exc
+
+    def _parse_link_file(self, path: Path) -> list[_ChEMBLEntry]:
+        if not path.exists():
+            raise FileNotFoundError(f"ChEMBL link file not found: {path}")
+
+        entries: list[_ChEMBLEntry] = []
+        for raw_line in path.read_text().splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            filename = Path(line).name
+            if not filename:
+                raise ValueError(f"Unable to determine filename for URL: {line}")
+            entries.append(_ChEMBLEntry(filename=filename, url=line))
+
+        if not entries:
+            raise ValueError(f"No download URLs found in {path}")
+        return entries
+
+    def _ensure_archive(self, entry: _ChEMBLEntry) -> Path:
+        target = self._download_dir / entry.filename
+        self._aria2_downloader(
+            entry.url,
+            target,
+            options=self._aria2_options,
+            skip_existing=True,
+        )
+        return target
+
+    def _build_record(self, properties: Mapping[str, str]) -> MoleculeRecord:
+        identifier = properties.get(self.config.identifier_tag, "").strip()
+        smiles = properties.get(self.config.smiles_tag, "").strip()
+        metadata: dict[str, str] = {
+            key: value
+            for key, value in properties.items()
+            if key not in {self.config.identifier_tag, self.config.smiles_tag}
+        }
+        if self.config.metadata_tags:
+            metadata = {
+                key: metadata[key]
+                for key in self.config.metadata_tags
+                if key in metadata
+            }
+        metadata = {key: value for key, value in metadata.items() if value}
+        return MoleculeRecord(
+            source=self.config.name,
+            identifier=identifier,
+            smiles=smiles,
+            metadata=metadata,
+        )
+
+    def _iter_records(self, entry: _ChEMBLEntry) -> Iterator[MoleculeRecord]:
+        archive = self._ensure_archive(entry)
+        for properties in iter_sdf_records(archive):
+            yield self._build_record(properties)
+
+    def fetch_pages(self) -> Iterator[IngestionPage]:
+        checkpoint = self._checkpoint_manager.load(self.config.name)
+        if checkpoint and checkpoint.completed:
+            logger.info("ingestion.skip", source=self.config.name, reason="completed")
+            return
+
+        start_file = 0
+        start_offset = 0
+        if checkpoint:
+            start_file = int(checkpoint.cursor.get("file_index", 0))
+            start_offset = int(checkpoint.cursor.get("record_offset", 0))
+
+        batch: list[MoleculeRecord] = []
+        entries = self._entries
+        for file_index in range(start_file, len(entries)):
+            entry = entries[file_index]
+            record_offset = start_offset if file_index == start_file else 0
+            processed = 0
+
+            for record in self._iter_records(entry):
+                if processed < record_offset:
+                    processed += 1
+                    continue
+                batch.append(record)
+                processed += 1
+                if len(batch) >= self.config.batch_size:
+                    next_cursor = {
+                        "file_index": file_index,
+                        "file_name": entry.filename,
+                        "record_offset": processed,
+                    }
+                    yield IngestionPage(records=list(batch), next_cursor=next_cursor)
+                    batch.clear()
+
+            start_offset = 0
+
+            if batch:
+                next_cursor = (
+                    {
+                        "file_index": file_index + 1,
+                        "file_name": entries[file_index + 1].filename
+                        if file_index + 1 < len(entries)
+                        else None,
+                        "record_offset": 0,
+                    }
+                    if file_index + 1 < len(entries)
+                    else None
+                )
+                yield IngestionPage(records=list(batch), next_cursor=next_cursor)
+                batch.clear()
+
+        if not entries:
+            yield IngestionPage(records=[], next_cursor=None)
+
+    def close(self) -> None:  # pragma: no cover - nothing to close
+        return
 
 
 __all__ = ["ChEMBLConfig", "ChEMBLConnector"]

--- a/src/open_molecule_data_pipeline/ingestion/cli.py
+++ b/src/open_molecule_data_pipeline/ingestion/cli.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 
 import click
-import structlog
 
+from ..logging_utils import get_logger
 from .runner import load_config, run_ingestion
 
-logger = structlog.get_logger(__name__)
+logger = get_logger(__name__)
 
 
 @click.command(name="ingest")

--- a/src/open_molecule_data_pipeline/ingestion/common.py
+++ b/src/open_molecule_data_pipeline/ingestion/common.py
@@ -9,11 +9,11 @@ from typing import Any
 
 import httpx
 import orjson
-import structlog
+from ..logging_utils import get_logger
 from pydantic import BaseModel, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-logger = structlog.get_logger(__name__)
+logger = get_logger(__name__)
 
 
 DEFAULT_USER_AGENT = "open-molecule-data-pipeline/0.1"

--- a/src/open_molecule_data_pipeline/ingestion/pubchem.py
+++ b/src/open_molecule_data_pipeline/ingestion/pubchem.py
@@ -1,76 +1,75 @@
-"""PubChem ingestion connector implementation."""
+"""PubChem ingestion connector implementation using local index manifests."""
 
 from __future__ import annotations
 
-import contextlib
-import gzip
-import tempfile
-from collections.abc import Callable, Iterable, Iterator, Mapping
+from dataclasses import dataclass
 from html.parser import HTMLParser
 from pathlib import Path
-from typing import Any
+from typing import Callable, Iterator, Mapping
 from urllib.parse import urljoin
 
-import httpx
-import structlog
 from pydantic import Field
 
+from ..logging_utils import get_logger
+from .aria2 import Aria2Options, download_with_aria2
 from .common import (
     BaseConnector,
     CheckpointManager,
     IngestionPage,
     MoleculeRecord,
     SourceConfig,
-    DEFAULT_USER_AGENT,
-    execute_request,
 )
+from .sdf import iter_sdf_records
 
-logger = structlog.get_logger(__name__)
+logger = get_logger(__name__)
 
 
-class _DirectoryListingParser(HTMLParser):
-    """Extract file names from an HTML directory index."""
+class _IndexLinkParser(HTMLParser):
+    """Collect all hyperlinks from an HTML index page."""
 
-    def __init__(self, suffixes: Iterable[str]) -> None:
+    def __init__(self) -> None:
         super().__init__()
-        self._suffixes = tuple(suffixes)
-        self._filenames: set[str] = set()
+        self._links: set[str] = set()
 
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str]]) -> None:
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         if tag.lower() != "a":
             return
-        href = None
-        for key, value in attrs:
-            if key.lower() == "href":
-                href = value
-                break
-        if not href:
-            return
-        candidate = href.split("#", 1)[0].split("?", 1)[0].strip()
-        if not candidate or not candidate.endswith(self._suffixes):
-            return
-        # Directory listings sometimes include relative paths; keep the base name.
-        filename = candidate.rsplit("/", 1)[-1]
-        if filename:
-            self._filenames.add(filename)
+        href = next((value for key, value in attrs if key.lower() == "href"), None)
+        if href:
+            self._links.add(href.strip())
 
-    def get_filenames(self) -> list[str]:
-        return sorted(self._filenames)
+    def links(self) -> list[str]:
+        return sorted(self._links)
+
+
+@dataclass(frozen=True)
+class _PubChemEntry:
+    filename: str
+    url: str
+    checksum_url: str | None
+    checksum_algorithm: str | None
 
 
 class PubChemConfig(SourceConfig):
-    """Configuration for downloading PubChem SDF bundles over HTTPS."""
+    """Configuration for downloading PubChem SDF bundles via :command:`aria2c`."""
 
-    base_url: str = "https://ftp.ncbi.nlm.nih.gov/pubchem/Compound/CURRENT-Full/SDF/"
-    timeout: float = 60.0
-    file_suffixes: list[str] = Field(default_factory=lambda: [".sdf.gz", ".sdf"])
+    index_file: Path = Field(description="Path to the saved PubChem HTML index page.")
+    download_dir: Path | None = Field(
+        default=None,
+        description="Directory where PubChem archives and checksum files are stored.",
+    )
+    base_url: str | None = Field(
+        default=None,
+        description="Optional base URL used when links inside the index are relative.",
+    )
     identifier_tag: str = "PUBCHEM_COMPOUND_CID"
     smiles_tag: str = "PUBCHEM_OPENEYE_ISO_SMILES"
     metadata_tags: list[str] = Field(default_factory=list)
+    aria2_options: dict[str, str | int | float | bool] = Field(default_factory=dict)
 
 
 class PubChemConnector(BaseConnector):
-    """Connector that downloads and parses PubChem SDF archives via HTTPS."""
+    """Connector that downloads and parses PubChem SDF archives."""
 
     config: PubChemConfig
 
@@ -78,108 +77,113 @@ class PubChemConnector(BaseConnector):
         self,
         config: PubChemConfig,
         checkpoint_manager: CheckpointManager,
-        client_factory: Callable[[], httpx.Client] | None = None,
+        aria2_downloader: Callable[..., None] | None = None,
     ) -> None:
         super().__init__(config=config, checkpoint_manager=checkpoint_manager)
-        self._client_factory = client_factory or self._create_default_client
-        self._client: httpx.Client | None = None
+        self._download_dir = self._resolve_download_dir()
+        self._aria2_downloader = aria2_downloader or download_with_aria2
+        self._aria2_options = self._build_aria2_options()
+        self._entries = self._parse_index(config.index_file)
 
-    def _create_default_client(self) -> httpx.Client:
-        return httpx.Client(
-            timeout=self.config.timeout,
-            headers={"User-Agent": DEFAULT_USER_AGENT},
-            follow_redirects=True,
-        )
+    def _resolve_download_dir(self) -> Path:
+        if self.config.download_dir is not None:
+            return self.config.download_dir
+        return self.config.index_file.resolve().parent
 
-    def _ensure_client(self) -> httpx.Client:
-        if self._client is None:
-            self._client = self._client_factory()
-        return self._client
-
-    def _list_remote_files(self, client: httpx.Client) -> list[str]:
-        request = client.build_request("GET", self.config.base_url)
-        response = execute_request(client, request)
+    def _build_aria2_options(self) -> Aria2Options:
+        options = self.config.aria2_options
+        if not options:
+            return Aria2Options()
         try:
-            parser = _DirectoryListingParser(self.config.file_suffixes)
-            parser.feed(response.text)
-            parser.close()
-            return parser.get_filenames()
-        finally:
-            response.close()
+            return Aria2Options(**options)
+        except TypeError as exc:  # pragma: no cover - validation guard
+            raise ValueError("Invalid aria2 options supplied") from exc
 
-    @contextlib.contextmanager
-    def _download_file(self, client: httpx.Client, filename: str) -> Iterator[Path]:
-        url = urljoin(self.config.base_url, filename)
-        request = client.build_request("GET", url)
-        response = execute_request(client, request)
-        temp_path: Path | None = None
-        try:
-            suffix = Path(filename).suffix
-            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
-                temp_path = Path(handle.name)
-                for chunk in response.iter_bytes():
-                    handle.write(chunk)
-        finally:
-            response.close()
+    def _parse_index(self, path: Path) -> list[_PubChemEntry]:
+        if not path.exists():
+            raise FileNotFoundError(f"PubChem index not found: {path}")
 
-        assert temp_path is not None  # pragma: no cover - defensive guard
-        try:
-            yield temp_path
-        finally:
-            with contextlib.suppress(FileNotFoundError):
-                temp_path.unlink()
+        parser = _IndexLinkParser()
+        parser.feed(path.read_text())
+        parser.close()
 
-    @contextlib.contextmanager
-    def _open_sdf_stream(self, path: Path) -> Iterator[Iterable[str]]:
-        if path.suffix == ".gz":
-            with gzip.open(path, "rt", encoding="utf-8", errors="replace") as stream:
-                yield stream
-        else:
-            with path.open("r", encoding="utf-8", errors="replace") as stream:
-                yield stream
+        sdf_links: dict[str, str] = {}
+        checksum_links: dict[str, tuple[str, str]] = {}
 
-    @staticmethod
-    def _parse_entry(lines: list[str]) -> dict[str, str]:
-        properties: dict[str, str] = {}
-        current_tag: str | None = None
-        buffer: list[str] = []
-        for line in lines:
-            if line.startswith(">"):
-                if current_tag is not None:
-                    properties[current_tag] = "\n".join(buffer).strip()
-                start = line.find("<")
-                end = line.find(">", start + 1)
-                if start != -1 and end != -1:
-                    current_tag = line[start + 1 : end].strip()
-                    buffer = []
-                else:
-                    current_tag = None
-                    buffer = []
-            elif current_tag is not None:
-                buffer.append(line.rstrip("\r"))
-        if current_tag is not None:
-            properties[current_tag] = "\n".join(buffer).strip()
-        return properties
+        for raw_href in parser.links():
+            resolved = self._resolve_href(raw_href)
+            name = Path(raw_href).name or Path(resolved).name
+            if not name:
+                continue
+            if name.endswith(".md5"):
+                target = name[:-4]
+                checksum_links[target] = (resolved, "md5")
+            elif name.endswith((".sdf", ".sdf.gz")):
+                sdf_links[name] = resolved
 
-    def _iter_sdf_entries(self, client: httpx.Client, filename: str) -> Iterator[dict[str, str]]:
-        with self._download_file(client, filename) as temp_path:
-            with self._open_sdf_stream(temp_path) as stream:
-                entry_lines: list[str] = []
-                for raw_line in stream:
-                    line = raw_line.rstrip("\n")
-                    if line.strip() == "$$$$":
-                        if entry_lines:
-                            yield self._parse_entry(entry_lines)
-                            entry_lines = []
-                    else:
-                        entry_lines.append(line)
-                if entry_lines:
-                    yield self._parse_entry(entry_lines)
+        entries: list[_PubChemEntry] = []
+        for filename in sorted(sdf_links):
+            checksum_url: str | None = None
+            checksum_alg: str | None = None
+            if filename in checksum_links:
+                checksum_url, checksum_alg = checksum_links[filename]
+            entries.append(
+                _PubChemEntry(
+                    filename=filename,
+                    url=sdf_links[filename],
+                    checksum_url=checksum_url,
+                    checksum_algorithm=checksum_alg,
+                )
+            )
+
+        if not entries:
+            raise ValueError(f"No SDF entries discovered in index: {path}")
+        return entries
+
+    def _resolve_href(self, href: str) -> str:
+        if href.startswith("http://") or href.startswith("https://"):
+            return href
+        if self.config.base_url is None:
+            raise ValueError(
+                "Index contains relative links but no base_url was configured: "
+                f"{href}"
+            )
+        return urljoin(self.config.base_url, href)
+
+    def _checksum_path(self, entry: _PubChemEntry) -> Path:
+        return self._download_dir / f"{entry.filename}.md5"
+
+    def _load_checksum(self, entry: _PubChemEntry) -> tuple[str, str] | None:
+        if not entry.checksum_url or not entry.checksum_algorithm:
+            return None
+        checksum_path = self._checksum_path(entry)
+        if not checksum_path.exists() or checksum_path.stat().st_size == 0:
+            self._aria2_downloader(
+                entry.checksum_url,
+                checksum_path,
+                options=self._aria2_options,
+                skip_existing=False,
+            )
+        content = checksum_path.read_text(encoding="utf-8", errors="ignore").strip()
+        if not content:
+            raise ValueError(f"Checksum file is empty: {checksum_path}")
+        value = content.split()[0]
+        return (entry.checksum_algorithm, value)
+
+    def _ensure_archive(self, entry: _PubChemEntry) -> Path:
+        target = self._download_dir / entry.filename
+        checksum = self._load_checksum(entry)
+        skip_existing = checksum is None
+        kwargs: dict[str, object] = {"options": self._aria2_options, "skip_existing": skip_existing}
+        if checksum:
+            kwargs["checksum"] = checksum
+        self._aria2_downloader(entry.url, target, **kwargs)
+        return target
 
     def _build_record(self, properties: Mapping[str, str]) -> MoleculeRecord:
         identifier = properties.get(self.config.identifier_tag, "").strip()
         smiles = properties.get(self.config.smiles_tag, "").strip()
-        metadata: dict[str, Any] = {
+        metadata: dict[str, str] = {
             key: value
             for key, value in properties.items()
             if key not in {self.config.identifier_tag, self.config.smiles_tag}
@@ -198,14 +202,16 @@ class PubChemConnector(BaseConnector):
             metadata=metadata,
         )
 
+    def _iter_records(self, entry: _PubChemEntry) -> Iterator[MoleculeRecord]:
+        archive = self._ensure_archive(entry)
+        for properties in iter_sdf_records(archive):
+            yield self._build_record(properties)
+
     def fetch_pages(self) -> Iterator[IngestionPage]:
         checkpoint = self._checkpoint_manager.load(self.config.name)
         if checkpoint and checkpoint.completed:
             logger.info("ingestion.skip", source=self.config.name, reason="completed")
             return
-
-        client = self._ensure_client()
-        filenames = self._list_remote_files(client)
 
         start_file = 0
         start_offset = 0
@@ -213,62 +219,50 @@ class PubChemConnector(BaseConnector):
             start_file = int(checkpoint.cursor.get("file_index", 0))
             start_offset = int(checkpoint.cursor.get("record_offset", 0))
 
-        if start_file >= len(filenames):
-            yield IngestionPage(records=[], next_cursor=None)
-            return
-
         batch: list[MoleculeRecord] = []
-        current_file = start_file
-        current_offset = start_offset
-        yielded = False
+        entries = self._entries
+        for file_index in range(start_file, len(entries)):
+            entry = entries[file_index]
+            record_offset = start_offset if file_index == start_file else 0
+            processed = 0
 
-        while current_file < len(filenames):
-            filename = filenames[current_file]
-            logger.info("ingestion.pubchem.file", source=self.config.name, file=filename)
-            entry_index = 0
-            for entry in self._iter_sdf_entries(client, filename):
-                if entry_index < current_offset:
-                    entry_index += 1
+            for record in self._iter_records(entry):
+                if processed < record_offset:
+                    processed += 1
                     continue
-                record = self._build_record(entry)
                 batch.append(record)
-                entry_index += 1
+                processed += 1
                 if len(batch) >= self.config.batch_size:
                     next_cursor = {
-                        "file_index": current_file,
-                        "file_name": filename,
-                        "record_offset": entry_index,
+                        "file_index": file_index,
+                        "file_name": entry.filename,
+                        "record_offset": processed,
                     }
-                    yielded = True
                     yield IngestionPage(records=list(batch), next_cursor=next_cursor)
                     batch.clear()
-            current_file += 1
-            current_offset = 0
+
+            start_offset = 0
+
             if batch:
                 next_cursor = (
                     {
-                        "file_index": current_file,
-                        "file_name": filenames[current_file]
-                        if current_file < len(filenames)
+                        "file_index": file_index + 1,
+                        "file_name": entries[file_index + 1].filename
+                        if file_index + 1 < len(entries)
                         else None,
                         "record_offset": 0,
                     }
-                    if current_file < len(filenames)
+                    if file_index + 1 < len(entries)
                     else None
                 )
-                yielded = True
                 yield IngestionPage(records=list(batch), next_cursor=next_cursor)
                 batch.clear()
 
-        if not yielded:
+        if not entries:
             yield IngestionPage(records=[], next_cursor=None)
 
-    def close(self) -> None:
-        if self._client is None:
-            return
-        with contextlib.suppress(Exception):
-            self._client.close()
-        self._client = None
+    def close(self) -> None:  # pragma: no cover - nothing to close
+        return
 
 
 __all__ = ["PubChemConfig", "PubChemConnector"]

--- a/src/open_molecule_data_pipeline/ingestion/runner.py
+++ b/src/open_molecule_data_pipeline/ingestion/runner.py
@@ -10,8 +10,6 @@ from typing import Any
 
 import inspect
 
-import httpx
-import structlog
 import yaml
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
@@ -26,10 +24,11 @@ from .common import (
     NDJSONWriter,
     SourceConfig,
 )
+from ..logging_utils import get_logger
 from .pubchem import PubChemConfig, PubChemConnector
 from .zinc import ZincConfig, ZincConnector
 
-logger = structlog.get_logger(__name__)
+logger = get_logger(__name__)
 
 ClientFactory = Callable[..., object]
 

--- a/src/open_molecule_data_pipeline/ingestion/sdf.py
+++ b/src/open_molecule_data_pipeline/ingestion/sdf.py
@@ -1,0 +1,64 @@
+"""Shared helpers for parsing Structure Data Files (SDF)."""
+
+from __future__ import annotations
+
+import gzip
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+
+
+def _open_sdf(path: Path) -> Iterator[str]:
+    if path.suffix == ".gz":
+        with gzip.open(path, "rt", encoding="utf-8", errors="replace") as stream:
+            for line in stream:
+                yield line.rstrip("\n")
+    else:
+        with path.open("r", encoding="utf-8", errors="replace") as stream:
+            for line in stream:
+                yield line.rstrip("\n")
+
+
+def _parse_entry(lines: Iterable[str]) -> dict[str, str]:
+    properties: dict[str, str] = {}
+    current_tag: str | None = None
+    buffer: list[str] = []
+
+    for line in lines:
+        if line.startswith(">"):
+            if current_tag is not None:
+                properties[current_tag] = "\n".join(buffer).strip()
+            start = line.find("<")
+            end = line.find(">", start + 1)
+            if start != -1 and end != -1:
+                current_tag = line[start + 1 : end].strip()
+                buffer = []
+            else:
+                current_tag = None
+                buffer = []
+        elif current_tag is not None:
+            buffer.append(line.rstrip("\r"))
+
+    if current_tag is not None:
+        properties[current_tag] = "\n".join(buffer).strip()
+
+    return properties
+
+
+def iter_sdf_records(path: Path) -> Iterator[dict[str, str]]:
+    """Yield property dictionaries for each SDF record in *path*."""
+
+    lines: list[str] = []
+    for line in _open_sdf(path):
+        if line.strip() == "$$$$":
+            if lines:
+                yield _parse_entry(lines)
+                lines = []
+        else:
+            lines.append(line)
+
+    if lines:
+        yield _parse_entry(lines)
+
+
+__all__ = ["iter_sdf_records"]
+

--- a/src/open_molecule_data_pipeline/logging_utils.py
+++ b/src/open_molecule_data_pipeline/logging_utils.py
@@ -1,0 +1,47 @@
+"""Lightweight logging helpers providing a structlog-compatible interface."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:  # pragma: no cover - optional dependency branch
+    import structlog
+except ImportError:  # pragma: no cover - fallback used in tests
+    structlog = None  # type: ignore[assignment]
+
+
+class _StructlogShim:
+    def __init__(self, name: str) -> None:
+        self._logger = logging.getLogger(name)
+
+    def _log(self, level: int, event: str, **kwargs: Any) -> None:
+        if kwargs:
+            self._logger.log(level, "%s %s", event, kwargs)
+        else:
+            self._logger.log(level, event)
+
+    def info(self, event: str, **kwargs: Any) -> None:
+        self._log(logging.INFO, event, **kwargs)
+
+    def warning(self, event: str, **kwargs: Any) -> None:
+        self._log(logging.WARNING, event, **kwargs)
+
+    def error(self, event: str, **kwargs: Any) -> None:
+        self._log(logging.ERROR, event, **kwargs)
+
+    def debug(self, event: str, **kwargs: Any) -> None:
+        self._log(logging.DEBUG, event, **kwargs)
+
+    def bind(self, **_: Any) -> "_StructlogShim":  # compatibility no-op
+        return self
+
+
+def get_logger(name: str):
+    if structlog is not None:  # pragma: no cover - depends on dependency graph
+        return structlog.get_logger(name)
+    logging.basicConfig(level=logging.INFO)
+    return _StructlogShim(name)
+
+
+__all__ = ["get_logger"]

--- a/tests/unit/ingestion/test_aria2.py
+++ b/tests/unit/ingestion/test_aria2.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from open_molecule_data_pipeline.ingestion.aria2 import Aria2Options, download_with_aria2
+
+
+def test_download_with_aria2_invokes_runner(tmp_path: Path) -> None:
+    commands: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> None:
+        commands.append(command)
+
+    target = tmp_path / "archive.dat"
+    download_with_aria2(
+        "https://example.test/archive.dat",
+        target,
+        runner=fake_runner,
+        options=Aria2Options(connections=8, split=4, min_split_size="2M"),
+    )
+
+    assert target.parent.exists()
+    assert len(commands) == 1
+    command = commands[0]
+    assert command[0] == "aria2c"
+    assert f"--dir={target.parent}" in command
+    assert f"--out={target.name}" in command
+    assert "--max-connection-per-server=8" in command
+    assert "--split=4" in command
+    assert "--min-split-size=2M" in command
+
+
+def test_skip_existing_file(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> None:
+        calls.append(command)
+
+    target = tmp_path / "archive.bin"
+    target.write_bytes(b"payload")
+
+    download_with_aria2(
+        "https://example.test/archive.bin",
+        target,
+        runner=fake_runner,
+    )
+
+    assert calls == []
+
+
+def test_resume_zero_length_file(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> None:
+        calls.append(command)
+
+    target = tmp_path / "partial.bin"
+    target.touch()
+
+    download_with_aria2(
+        "https://example.test/archive.bin",
+        target,
+        runner=fake_runner,
+    )
+
+    assert len(calls) == 1
+    assert "--continue=true" in calls[0]
+
+
+def test_checksum_failure(tmp_path: Path) -> None:
+    def failing_runner(command: list[str]) -> None:
+        raise subprocess.CalledProcessError(returncode=1, cmd=command)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        download_with_aria2(
+            "https://example.test/archive.bin",
+            tmp_path / "archive.bin",
+            checksum=("md5", "deadbeef"),
+            runner=failing_runner,
+        )
+
+
+def test_authentication_arguments(tmp_path: Path) -> None:
+    commands: list[list[str]] = []
+
+    def fake_runner(command: list[str]) -> None:
+        commands.append(command)
+
+    download_with_aria2(
+        "https://example.test/archive.bin",
+        tmp_path / "archive.bin",
+        username="user",
+        password="pass",
+        runner=fake_runner,
+    )
+
+    assert any("--http-user" in part for part in commands[0])
+    assert "user" in commands[0]
+    assert "pass" in commands[0]

--- a/tests/unit/ingestion/test_pubchem.py
+++ b/tests/unit/ingestion/test_pubchem.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import gzip
+import hashlib
 import io
 from pathlib import Path
-
-import httpx
+from typing import Any
 
 from open_molecule_data_pipeline.ingestion.common import (
     CheckpointManager,
@@ -40,52 +40,69 @@ def _sdf_entry(cid: str, smiles: str, **metadata: str) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _mock_pubchem_client(files: dict[str, bytes], base_url: str) -> httpx.Client:
-    base = httpx.URL(base_url)
-    listing_path = base.path
-    if not listing_path.endswith("/"):
-        listing_path = f"{listing_path}/"
+def _write_index(path: Path, filenames: list[str]) -> None:
+    links = "".join(f'<a href="{name}">{name}</a>\n' for name in filenames)
+    path.write_text(f"<html><body>{links}</body></html>")
 
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.method != "GET":  # pragma: no cover - defensive guard
-            return httpx.Response(405)
 
-        path = request.url.path
-        if path.rstrip("/") == listing_path.rstrip("/"):
-            links = "".join(
-                f'<a href="{name}">{name}</a>' for name in sorted(files)
-            )
-            html = f"<html><body>{links}</body></html>"
-            return httpx.Response(200, text=html)
+def _build_downloader(fixtures: dict[str, bytes], checksum_suffix: str = ".md5"):
+    calls: list[dict[str, Any]] = []
 
-        if not path.startswith(listing_path):
-            return httpx.Response(404)
+    def downloader(url: str, output_path: Path, **kwargs: Any) -> None:
+        calls.append({"url": url, "kwargs": kwargs, "output": output_path})
+        if url.endswith(checksum_suffix):
+            value = fixtures[url].decode("utf-8")
+            output_path.write_text(value)
+        else:
+            output_path.write_bytes(fixtures[url])
 
-        filename = path[len(listing_path) :]
-        if filename not in files:
-            return httpx.Response(404)
-        return httpx.Response(200, content=files[filename])
-
-    transport = httpx.MockTransport(handler)
-    return httpx.Client(transport=transport, timeout=5.0)
+    return downloader, calls
 
 
 def test_pubchem_connector_batches_records(tmp_path: Path) -> None:
-    file_a = _gzip_bytes(_sdf_entry("CID1", "C") + _sdf_entry("CID2", "CC"))
-    file_b = _gzip_bytes(_sdf_entry("CID3", "CCC", PUBCHEM_IUPAC_NAME="Propane"))
-    files = {"file_a.sdf.gz": file_a, "file_b.sdf.gz": file_b}
-    base_url = "https://example.test/pubchem/Compound/CURRENT-Full/SDF/"
+    sdf_a = _gzip_bytes(_sdf_entry("CID1", "C") + _sdf_entry("CID2", "CC"))
+    sdf_b = _gzip_bytes(_sdf_entry("CID3", "CCC", PUBCHEM_IUPAC_NAME="Propane"))
+    md5_a = hashlib.md5(sdf_a).hexdigest().encode("utf-8")
+    md5_b = hashlib.md5(sdf_b).hexdigest().encode("utf-8")
 
-    manager = CheckpointManager(tmp_path)
+    base_url = "https://example.test/pubchem/"
+    filenames = [
+        "Compound_A.sdf.gz",
+        "Compound_A.sdf.gz.md5",
+        "Compound_B.sdf.gz",
+        "Compound_B.sdf.gz.md5",
+    ]
+    index_file = tmp_path / "index.html"
+    _write_index(index_file, filenames)
+
+    fixtures = {
+        url: payload
+        for url, payload in {
+            f"{base_url}Compound_A.sdf.gz": sdf_a,
+            f"{base_url}Compound_A.sdf.gz.md5": md5_a + b"  Compound_A.sdf.gz\n",
+            f"{base_url}Compound_B.sdf.gz": sdf_b,
+            f"{base_url}Compound_B.sdf.gz.md5": md5_b + b"  Compound_B.sdf.gz\n",
+        }.items()
+    }
+
+    downloader, calls = _build_downloader(fixtures)
+
+    manager = CheckpointManager(tmp_path / "checkpoints")
     connector = PubChemConnector(
-        config=PubChemConfig(name="pubchem", batch_size=2, base_url=base_url),
+        config=PubChemConfig(
+            name="pubchem",
+            batch_size=2,
+            index_file=index_file,
+            download_dir=tmp_path / "downloads",
+            base_url=base_url,
+        ),
         checkpoint_manager=manager,
-        client_factory=lambda: _mock_pubchem_client(files, base_url),
+        aria2_downloader=downloader,
     )
 
     pages = list(connector.fetch_pages())
-    assert len(pages) == 2
 
+    assert len(pages) == 2
     first, second = pages
     assert [record.identifier for record in first.records] == ["CID1", "CID2"]
     assert isinstance(first.next_cursor, dict)
@@ -94,38 +111,54 @@ def test_pubchem_connector_batches_records(tmp_path: Path) -> None:
     assert [record.identifier for record in second.records] == ["CID3"]
     assert second.next_cursor is None
 
-    connector.close()
+    checksum_urls = [call["url"] for call in calls if call["url"].endswith(".md5")]
+    assert len(checksum_urls) == 2
 
 
 def test_pubchem_connector_resumes_from_checkpoint(tmp_path: Path) -> None:
-    sdf_payload = _sdf_entry("CID1", "C") + _sdf_entry("CID2", "CC") + _sdf_entry("CID3", "CCC")
-    files = {"chunk.sdf.gz": _gzip_bytes(sdf_payload)}
-    base_url = "https://example.test/pubchem/Compound/CURRENT-Full/SDF/"
+    payload = _gzip_bytes(
+        _sdf_entry("CID1", "C")
+        + _sdf_entry("CID2", "CC")
+        + _sdf_entry("CID3", "CCC")
+    )
+    md5_payload = hashlib.md5(payload).hexdigest().encode("utf-8")
 
-    manager = CheckpointManager(tmp_path)
+    base_url = "https://example.test/pubchem/"
+    filenames = ["Chunk.sdf.gz", "Chunk.sdf.gz.md5"]
+    index_file = tmp_path / "index.html"
+    _write_index(index_file, filenames)
+
+    fixtures = {
+        f"{base_url}Chunk.sdf.gz": payload,
+        f"{base_url}Chunk.sdf.gz.md5": md5_payload + b"  Chunk.sdf.gz\n",
+    }
+
+    downloader, calls = _build_downloader(fixtures)
+
+    manager = CheckpointManager(tmp_path / "checkpoints")
     connector = PubChemConnector(
-        config=PubChemConfig(name="pubchem", batch_size=2, base_url=base_url),
+        config=PubChemConfig(
+            name="pubchem",
+            batch_size=2,
+            index_file=index_file,
+            download_dir=tmp_path / "downloads",
+            base_url=base_url,
+        ),
         checkpoint_manager=manager,
-        client_factory=lambda: _mock_pubchem_client(files, base_url),
+        aria2_downloader=downloader,
     )
 
-    page_iter = connector.fetch_pages()
-    first_page = next(page_iter)
+    first_page = next(connector.fetch_pages())
     manager.store(
         "pubchem",
         IngestionCheckpoint(cursor=first_page.next_cursor or {}, batch_index=1, completed=False),
     )
-    connector.close()
 
-    resume_connector = PubChemConnector(
-        config=PubChemConfig(name="pubchem", batch_size=2, base_url=base_url),
-        checkpoint_manager=manager,
-        client_factory=lambda: _mock_pubchem_client(files, base_url),
-    )
-
-    remaining_pages = list(resume_connector.fetch_pages())
+    remaining_pages = list(connector.fetch_pages())
     assert len(remaining_pages) == 1
     remaining = remaining_pages[0]
     assert [record.identifier for record in remaining.records] == ["CID3"]
     assert remaining.next_cursor is None
-    resume_connector.close()
+
+    checksum_calls = [call for call in calls if call["url"].endswith(".md5")]
+    assert checksum_calls

--- a/tests/unit/ingestion/test_zinc.py
+++ b/tests/unit/ingestion/test_zinc.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import gzip
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-from ingestion.common import CheckpointManager, IngestionCheckpoint
-from ingestion.zinc import ZincConfig, ZincConnector
+from open_molecule_data_pipeline.ingestion.common import (
+    CheckpointManager,
+    IngestionCheckpoint,
+)
+from open_molecule_data_pipeline.ingestion.zinc import ZincConfig, ZincConnector
 
 
 def _write_gzip_lines(path: Path, lines: list[str]) -> None:
@@ -19,12 +23,13 @@ def _write_gzip_lines(path: Path, lines: list[str]) -> None:
 
 def _create_wget_script(path: Path, relative_path: str) -> None:
     path.write_text(
-        "mkdir -pv H04 && wget https://files.docking.org/zinc22/2d/H04/H04M000.smi.gz"
+        "mkdir -pv H04 && wget --user user --password pass "
+        "https://files.docking.org/zinc22/2d/H04/H04M000.smi.gz"
         f" -O {relative_path}\n"
     )
 
 
-def test_fetch_pages_from_wget_script(tmp_path: Path) -> None:
+def test_fetch_pages_uses_existing_archives(tmp_path: Path) -> None:
     download_dir = tmp_path / "downloads"
     archive_path = download_dir / "H04" / "H04M000.smi.gz"
     _write_gzip_lines(
@@ -46,20 +51,82 @@ def test_fetch_pages_from_wget_script(tmp_path: Path) -> None:
         batch_size=2,
     )
     checkpoint_manager = CheckpointManager(tmp_path / "checkpoints")
-    connector = ZincConnector(config=config, checkpoint_manager=checkpoint_manager)
+
+    called: dict[str, Any] = {}
+
+    def fake_downloader(*args: object, **kwargs: object) -> None:
+        called["invoked"] = True
+
+    connector = ZincConnector(
+        config=config,
+        checkpoint_manager=checkpoint_manager,
+        aria2_downloader=fake_downloader,
+    )
 
     pages = list(connector.fetch_pages())
 
+    assert "invoked" not in called
     assert len(pages) == 2
     first_page, second_page = pages
-
-    assert len(first_page.records) == 2
-    assert first_page.records[0].identifier == "ZINC00000001"
-    assert first_page.records[0].smiles == "C"
-    assert first_page.records[0].metadata["source_file"] == "H04/H04M000.smi.gz"
-
-    assert len(second_page.records) == 1
+    assert [record.identifier for record in first_page.records] == ["ZINC00000001", "ZINC00000002"]
+    assert [record.identifier for record in second_page.records] == ["ZINC00000003"]
     assert second_page.next_cursor is None
+
+
+def test_missing_archive_triggers_download(tmp_path: Path) -> None:
+    script_path = tmp_path / "zinc.wget"
+    _create_wget_script(script_path, "H04/H04M000.smi.gz")
+
+    downloaded: dict[str, Any] = {}
+
+    def fake_downloader(url: str, output_path: Path, **kwargs: object) -> None:
+        downloaded["url"] = url
+        downloaded["kwargs"] = kwargs
+        _write_gzip_lines(
+            output_path,
+            [
+                "C\tZINC00000001",
+                "CC\tZINC00000002",
+            ],
+        )
+
+    config = ZincConfig(
+        name="zinc",
+        wget_file=script_path,
+        download_dir=tmp_path / "downloads",
+        batch_size=2,
+        download_missing=True,
+    )
+    checkpoint_manager = CheckpointManager(tmp_path / "checkpoints")
+    connector = ZincConnector(
+        config=config,
+        checkpoint_manager=checkpoint_manager,
+        aria2_downloader=fake_downloader,
+    )
+
+    pages = list(connector.fetch_pages())
+
+    assert downloaded["url"].endswith("H04M000.smi.gz")
+    assert downloaded["kwargs"]["username"] == "user"
+    assert downloaded["kwargs"]["password"] == "pass"
+    assert len(pages) == 1
+    assert [record.identifier for record in pages[0].records] == ["ZINC00000001", "ZINC00000002"]
+
+
+def test_missing_archive_without_download(tmp_path: Path) -> None:
+    script_path = tmp_path / "zinc.wget"
+    _create_wget_script(script_path, "H04/H04M000.smi.gz")
+
+    config = ZincConfig(
+        name="zinc",
+        wget_file=script_path,
+        download_dir=tmp_path / "downloads",
+    )
+    checkpoint_manager = CheckpointManager(tmp_path / "checkpoints")
+    connector = ZincConnector(config=config, checkpoint_manager=checkpoint_manager)
+
+    with pytest.raises(FileNotFoundError):
+        list(connector.fetch_pages())
 
 
 def test_fetch_pages_respects_checkpoint(tmp_path: Path) -> None:
@@ -93,22 +160,4 @@ def test_fetch_pages_respects_checkpoint(tmp_path: Path) -> None:
     pages = list(connector.fetch_pages())
 
     assert len(pages) == 1
-    assert len(pages[0].records) == 1
-    assert pages[0].records[0].identifier == "ZINC00000003"
-
-
-def test_missing_archive_raises_without_download(tmp_path: Path) -> None:
-    download_dir = tmp_path / "downloads"
-    script_path = tmp_path / "zinc.wget"
-    _create_wget_script(script_path, "H04/H04M000.smi.gz")
-
-    config = ZincConfig(
-        name="zinc",
-        wget_file=script_path,
-        download_dir=download_dir,
-    )
-    checkpoint_manager = CheckpointManager(tmp_path / "checkpoints")
-    connector = ZincConnector(config=config, checkpoint_manager=checkpoint_manager)
-
-    with pytest.raises(FileNotFoundError):
-        list(connector.fetch_pages())
+    assert [record.identifier for record in pages[0].records] == ["ZINC00000003"]


### PR DESCRIPTION
## Summary
- add a shared aria2c download helper and logging shim to remove the hard dependency on structlog
- refactor the ZINC, PubChem, and ChEMBL connectors to rely on the local link manifests and the aria2 workflow, sharing a new SDF parser
- refresh the unit tests and documentation to cover the aria2 integration and bulk-download ingest flow

## Testing
- `uv run pytest --override-ini addopts=""` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68da5d4973348321acabcec912ac29bc